### PR TITLE
Add `~here:[%here]` argument to failwiths

### DIFF
--- a/lib/rest.ml
+++ b/lib/rest.ml
@@ -164,7 +164,7 @@ struct
      `Service_unavailable body
     | (code : Cohttp.Code.status_code) ->
       Cohttp_async.Body.to_string body >>| fun body ->
-      failwiths (sprintf "unexpected status code (body=%S)" body)
+      failwiths ~here:[%here] (sprintf "unexpected status code (body=%S)" body)
         code Cohttp.Code.sexp_of_status_code
 end
 
@@ -196,6 +196,7 @@ struct
                ); Log.Global.flushed ()
            | #Error.post as post_error ->
              failwiths
+               ~here:[%here]
                (sprintf
                   "post for operation %S failed"
                   (Path.to_string Operation.path)
@@ -230,6 +231,7 @@ struct
                ); Log.Global.flushed ()
            | #Error.post as post_error ->
              failwiths
+               ~here:[%here]
                (sprintf
                   "post for operation %S failed"
                   (Path.to_string Operation.path)


### PR DESCRIPTION
FYI, we're about to make the following change to Jane Street libraries.  This PR is designed to help alleviate breakage:

`failwiths`'s source code position argument is now required.  This
argument used to be added by `ppx_fail`, but that ppx is going away,
so this change has no impact on behavior.