### PR TITLE
Dependency updates

### DIFF
--- a/gemini.opam
+++ b/gemini.opam
@@ -27,7 +27,7 @@ depends: [
   "yojson" {>= "1.7.0"}
   "zarith"
   "nocrypto"
-  "ppx_deriving_yojson"
+  "ppx_deriving_yojson" {>= "3.6.1"}
   "ppx_csv_conv"
   "csvfields"
   "websocket-async"

--- a/lib/csv_support.ml
+++ b/lib/csv_support.ml
@@ -34,7 +34,7 @@ module Optional = struct
       let to_string t =
         Option.value_map ~default:C.null t ~f:C.to_string
       let of_string s =
-        if C.null = s then None else Some (C.of_string s)
+        if String.equal C.null s then None else Some (C.of_string s)
     end
     include T
     include (Csvfields.Csv.Atom(T) : Csvfields.Csv.Csvable with type t := t)

--- a/lib/json.ml
+++ b/lib/json.ml
@@ -29,25 +29,25 @@ module type S = sig
   val of_string : string -> t
   val to_string : t -> string
   val is_csv_atom : bool
-  val rev_csv_header' : string sexp_list -> 'a -> 'b -> string sexp_list
+  val rev_csv_header' : string list -> 'a -> 'b -> string list
   val rev_csv_header_spec' :
-    Csvfields.Csv.Spec.t sexp_list ->
-    'a -> 'b -> Csvfields.Csv.Spec.t sexp_list
-  val t_of_row' : 'a -> string sexp_list -> (unit -> t) * string sexp_list
+    Csvfields.Csv.Spec.t list ->
+    'a -> 'b -> Csvfields.Csv.Spec.t list
+  val t_of_row' : 'a -> string list -> (unit -> t) * string list
   val write_row_of_t' :
     is_first:bool ->
     is_last:bool -> writer:(string -> unit) -> 'a -> 'b -> t -> unit
-  val csv_header : string sexp_list
-  val csv_header_spec : Csvfields.Csv.Spec.t sexp_list
-  val t_of_row : string sexp_list -> t
-  val row_of_t : t -> string sexp_list
-  val csv_load : ?separator:char -> string -> t sexp_list
-  val csv_load_in : ?separator:char -> In_channel.t -> t sexp_list
+  val csv_header : string list
+  val csv_header_spec : Csvfields.Csv.Spec.t list
+  val t_of_row : string list -> t
+  val row_of_t : t -> string list
+  val csv_load : ?separator:char -> string -> t list
+  val csv_load_in : ?separator:char -> In_channel.t -> t list
   val csv_save_fn :
-    ?separator:char -> (string -> unit) -> t sexp_list -> unit
+    ?separator:char -> (string -> unit) -> t list -> unit
   val csv_save_out :
-    ?separator:char -> Out_channel.t -> t sexp_list -> unit
-  val csv_save : ?separator:char -> string -> t sexp_list -> unit
+    ?separator:char -> Out_channel.t -> t list -> unit
+  val csv_save : ?separator:char -> string -> t list -> unit
   end
 (** An enumeration encodable as a json string. *)
 module type ENUM_STRING = sig

--- a/lib/market_data.mli
+++ b/lib/market_data.mli
@@ -208,7 +208,7 @@ include Ws.CHANNEL
 
 val client :
   (module Cfg.S) ->
-  ?query:Sexp.t sexp_list ->
+  ?query:Sexp.t list ->
   ?uri_args:uri_args -> unit ->
   response Pipe.Reader.t Deferred.t
 

--- a/lib/rest.mli
+++ b/lib/rest.mli
@@ -65,7 +65,7 @@ sig
   sig
     type t = [ `Error | `Ok ] [@@derivin sexp, yojson, enumerate]
     val to_string : t -> string
-    val dict : (string * t) sexp_list
+    val dict : (string * t) list
     val of_string : string -> t
     val of_string_opt : string -> t option
      val split :

--- a/lib/ws.ml
+++ b/lib/ws.ml
@@ -235,7 +235,7 @@ let client (module Cfg : Cfg.S)
       Uri.(scheme uri) in
   let tcp_fun s r w =
     Socket.(setopt s Opt.nodelay true);
-    (if scheme = "https" || scheme = "wss" then
+    (if String.(equal scheme "https" || equal scheme "wss") then
        (Unix.Inet_addr.of_string_or_getbyname host >>|
         Ipaddr_unix.of_inet_addr
        ) >>= fun addr ->
@@ -297,7 +297,8 @@ let handle_client addr reader writer =
   let check_request req =
     let req_str = Format.asprintf "%a" Cohttp.Request.pp_hum req in
     Log.Global.info "Incoming connnection request: %s" req_str ;
-    Deferred.return (Cohttp.Request.(uri req |> Uri.path) = "/ws")
+    let path = Cohttp.Request.uri req |> Uri.path in
+    Deferred.return (String.equal path "/ws")
   in
   let rec loop () =
     Pipe.read receiver_read >>= function
@@ -338,8 +339,11 @@ let handle_client addr reader writer =
   Deferred.any [
     begin Websocket_async.server
         ~check_request ~app_to_ws ~ws_to_app ~reader ~writer () >>= function
-      | Error err when Error.to_exn err = Exit -> Deferred.unit
-      | Error err -> Error.raise err
+      | Error err ->
+         (match Error.to_exn err with 
+          | Exit -> Deferred.unit
+          | (_:Exn.t) -> Error.raise err
+         )
       | Ok () -> Deferred.unit
     end ;
     loop () ;


### PR DESCRIPTION
- Upgrades to latest `ppx_deriving_yojson=3.6.1` to fix an error with `[@deriving None]`
- Removes uses of `=` to support latest janestreet core.
- Takes `sexp_list` out of signatures.
