### PR TITLE
Add more currencies

### DIFF
--- a/lib/common.ml
+++ b/lib/common.ml
@@ -29,6 +29,7 @@ module Decimal_string = struct
   let of_string t = t
   let to_string t = t
 end
+
 (** Represents an order side. *)
 module Side =
 struct
@@ -60,6 +61,7 @@ module Symbol = struct
       | `Zecusd | `Zecbtc | `Zeceth | `Zecbch | `Zecltc
       | `Ltcusd | `Ltcbtc | `Ltceth | `Ltcbch
       | `Bchusd | `Bchbtc | `Bcheth
+      | `Lunausd | `Xtzusd
       ]
     [@@deriving sexp, enumerate]
 
@@ -79,6 +81,8 @@ module Symbol = struct
       | `Ltcbtc -> "ltcbtc"
       | `Ltceth -> "ltceth"
       | `Ltcbch -> "ltcbch"
+      | `Lunausd -> "lunausd"
+      | `Xtzusd -> "xtzusd"
 
 
   end
@@ -176,7 +180,7 @@ module Currency = struct
     (** An enumerated set of all supported currencies supported
         currently by Gemini.
     *)
-    type t = [`Eth | `Btc | `Usd | `Zec | `Bch | `Ltc]
+    type t = [`Eth | `Btc | `Usd | `Zec | `Bch | `Ltc | `Luna | `Xtz]
     [@@deriving sexp, enumerate]
     let to_string = function
       | `Eth -> "eth"
@@ -185,6 +189,8 @@ module Currency = struct
       | `Zec -> "zec"
       | `Bch -> "bch"
       | `Ltc -> "ltc"
+      | `Luna -> "luna"
+      | `Xtz -> "xtz"
   end
   include T
   include (Json.Make(T) : Json.S with type t := t)

--- a/lib/gemini.ml
+++ b/lib/gemini.ml
@@ -226,8 +226,8 @@ module V1 = struct
 
   module Tradevolume = struct
 
-    type volume =
-      {account_id:Int_number.t;
+    type volume = {
+       account_id:(Int_number.t option [@default None]);
        symbol:Symbol.t;
        base_currency:Currency.t;
        notional_currency:Currency.t;

--- a/lib/gemini.mli
+++ b/lib/gemini.mli
@@ -267,6 +267,7 @@ module V1 : sig
         ] Deferred.t
       val command : string * Command.t
     end
+  
   (** Gets all trade volume executed by on the
       Gemini trading exchange over the REST api. *)
   module Tradevolume :
@@ -276,7 +277,7 @@ module V1 : sig
           one particular symbol on the Gemini trading exchange.
       *)
       type volume = {
-        account_id : Int_number.t;
+        account_id : Int_number.t option;
         symbol : Symbol.t;
         base_currency : Currency.t;
         notional_currency : Currency.t;


### PR DESCRIPTION
Adds support for luna and xtz. Missing about 60 other tokens though which will be done in a subsequent PR.

Make `account_id` field optional to support changes in the trade volume spec.