### PR TITLE
Support for Notional volume api

### DIFF
--- a/.ocamlinit
+++ b/.ocamlinit
@@ -3,8 +3,8 @@ let () =
   with Not_found -> ()
 ;;
 
-#use "topfind";;
-#thread;;
+(*#use "topfind";; *)
+(*#thread;; *)
 #require "core hex async csvfields cohttp.async nocrypto ppx_deriving.runtime ppx_deriving_yojson.runtime ppx_inline_test.runtime-lib ppx_jane zarith uri yojson websocket-async";;
 
 #load "compiler-libs/ocamlcommon.cma";;

--- a/.ocamlinit
+++ b/.ocamlinit
@@ -3,9 +3,9 @@ let () =
   with Not_found -> ()
 ;;
 
-(*#use "topfind";; *)
-(*#thread;; *)
-#require "core hex async csvfields cohttp.async nocrypto ppx_deriving.runtime ppx_deriving_yojson.runtime ppx_inline_test.runtime-lib ppx_jane zarith uri yojson websocket-async";;
+#use "topfind";; 
+#thread;;
+#require "core hex async csvfields cohttp-async nocrypto ppx_deriving.runtime ppx_deriving_yojson.runtime ppx_inline_test.runtime-lib ppx_jane zarith uri yojson websocket-async";;
 
 #load "compiler-libs/ocamlcommon.cma";;
 

--- a/lib/gemini.ml
+++ b/lib/gemini.ml
@@ -5,7 +5,7 @@ module Cfg = Cfg
 module Nonce = Nonce
 module Rest = Rest
 module Result = Json.Result
-
+module Inf_pipe = Inf_pipe
 
 module V1 = struct
   let path = ["v1"]

--- a/lib/gemini.ml
+++ b/lib/gemini.ml
@@ -283,6 +283,41 @@ module V1 = struct
     include Rest.Make_no_arg(T)
   end
 
+  module Notional_volume = struct
+
+    module T = struct
+      let name = "notionalvolume"
+      let path = path@["notionalvolume"]
+
+      type request = {symbol: Symbol.t option [@default None]; account: string option [@default None]} [@@deriving yojson, sexp]
+      type notional_1d_volume = {
+          date: string (* TODO use strict a date type *);
+          notional_volume: Decimal_number.t;
+      } [@@deriving sexp, yojson]
+      type response =
+          {last_updated_ms: Timestamp.Ms.t;
+           web_maker_fee_bps: Int_number.t;
+           web_taker_fee_bps: Int_number.t;
+           web_auction_fee_bps: Int_number.t;
+           api_maker_fee_bps: Int_number.t;
+           api_taker_fee_bps: Int_number.t;
+           api_auction_fee_bps: Int_number.t;
+           fix_maker_fee_bps: Int_number.t;
+           fix_taker_fee_bps: Int_number.t;
+           fix_auction_fee_bps: Int_number.t;
+           block_maker_fee_bps: Int_number.t;
+           block_taker_fee_bps: Int_number.t;
+           date: string (* TODO use strict a date type *);
+           notional_30d_volume: Decimal_number.t;
+           notional_1d_volume: notional_1d_volume list
+          } [@@deriving yojson, sexp]
+    end
+
+    include T
+    include Rest.Make(T)
+  end
+
+
   let command : Command.t =
     Command.group
       ~summary:"Gemini Command System"
@@ -293,7 +328,10 @@ module V1 = struct
        Tradevolume.command;
        Balances.command;
        Market_data.command;
-       Order_events.command
+       Order_events.command;
+       Notional_volume.command
       ]
+
+
 
 end

--- a/lib/gemini.mli
+++ b/lib/gemini.mli
@@ -355,6 +355,46 @@ module V1 : sig
         ] Deferred.t
       val command : string * Command.t
     end
+
+module Notional_volume :
+    sig
+
+      type request = {symbol: Symbol.t option [@default None]; account: string option [@default None]} [@@deriving of_yojson, sexp]
+      type notional_1d_volume = {
+          date: string (* TODO use strict a date type *);
+          notional_volume: Decimal_number.t;
+      } [@@deriving sexp, yojson]
+      type response =
+          {last_updated_ms: Timestamp.Ms.t;
+           web_maker_fee_bps: Int_number.t;
+           web_taker_fee_bps: Int_number.t;
+           web_auction_fee_bps: Int_number.t;
+           api_maker_fee_bps: Int_number.t;
+           api_taker_fee_bps: Int_number.t;
+           api_auction_fee_bps: Int_number.t;
+           fix_maker_fee_bps: Int_number.t;
+           fix_taker_fee_bps: Int_number.t;
+           fix_auction_fee_bps: Int_number.t;
+           block_maker_fee_bps: Int_number.t;
+           block_taker_fee_bps: Int_number.t;
+           date: string (* TODO use strict a date type *);
+           notional_30d_volume: Decimal_number.t;
+           notional_1d_volume: notional_1d_volume list
+          } [@@deriving sexp]
+      include Rest.Operation.S
+        with type request := request
+        with type response := response
+       val post :
+        (module Cfg.S) ->
+        Nonce.reader ->
+        request ->
+        [
+          | Rest.Error.post
+          | `Ok of response
+        ] Deferred.t
+      val command : string * Command.t
+  end
+
   module Market_data = Market_data
   val command : Command.t
 end

--- a/lib/gemini.mli
+++ b/lib/gemini.mli
@@ -19,6 +19,7 @@ module Cfg = Cfg
 module Nonce = Nonce
 module Rest = Rest
 module Result = Json.Result
+module Inf_pipe = Inf_pipe
 
 (** Version v1 of the Gemini REST and web socket apis. *)
 module V1 : sig

--- a/lib/inf_pipe.ml
+++ b/lib/inf_pipe.ml
@@ -1,0 +1,56 @@
+open Async
+
+module T = struct
+
+module Reader = struct
+  type 'a t = 'a Pipe.Reader.t
+  let create (reader: 'a Pipe.Reader.t ) : 'a t = reader
+end 
+
+let read ?consumer t =
+    Pipe.read ?consumer t >>| function `Ok x -> x | `Eof -> assert false
+
+let read_now ?consumer t =
+    Pipe.read_now ?consumer t |> function
+    | `Ok _ as ok -> ok
+    | `Nothing_available as na -> na
+    | `Eof -> assert false
+
+let read_exactly ?consumer t ~num_values =
+      Pipe.read_exactly ?consumer t ~num_values >>| function
+        | `Exactly e -> e
+        | `Fewer _ | `Eof -> assert false
+
+let unfold ~init ~f : 'a Reader.t =
+    Pipe.unfold ~init ~f:(fun (acc : 's) ->
+        f acc >>| fun (acc, s) -> Some (acc, s))
+
+let map = Pipe.map
+let filter_map = Pipe.filter_map
+
+let to_pipe t : 'a Pipe.Reader.t = t
+end
+
+module type S = sig
+
+  module Reader: sig 
+    type 'a t = private 'a Pipe.Reader.t 
+    val create : 'a Pipe.Reader.t  -> 'a t 
+  end
+  val read : ?consumer:Pipe.Consumer.t -> 'a Reader.t -> 'a Deferred.t
+  val read_now :
+    ?consumer:Pipe.Consumer.t ->
+    'a Reader.t -> [> `Nothing_available | `Ok of 'a ]
+  val read_exactly :
+    ?consumer:Pipe.Consumer.t ->
+    'a Reader.t -> num_values:int -> 'a Base.Queue.t Deferred.t
+  val unfold : init:'s -> f:('s -> ('a * 's) Deferred.t) -> 'a Reader.t
+  val map : 'a Reader.t -> f:('a -> 'b) -> 'b Reader.t
+  val filter_map :
+     ?max_queue_length:int -> 'a Reader.t -> f:('a -> 'b option) -> 'b Reader.t
+
+  val to_pipe : 'a Reader.t -> 'a Pipe.Reader.t
+end
+
+
+include (T : S)

--- a/lib/inf_pipe.ml
+++ b/lib/inf_pipe.ml
@@ -33,8 +33,8 @@ end
 
 module type S = sig
 
-  module Reader: sig 
-    type 'a t = private 'a Pipe.Reader.t 
+  module Reader: sig
+    type 'a t = private 'a Pipe.Reader.t
     val create : 'a Pipe.Reader.t  -> 'a t 
   end
   val read : ?consumer:Pipe.Consumer.t -> 'a Reader.t -> 'a Deferred.t

--- a/lib/nonce.ml
+++ b/lib/nonce.ml
@@ -74,7 +74,7 @@ module Request = struct
     | `Ok nonce ->
       return
         {request;nonce;payload}
-    | `Eof -> assert false
+    | `Eof -> failwith("Got unexpected EOF from nonce reader")
 
   let to_yojson {request;nonce;payload} : Yojson.Safe.t =
     match request_nonce_to_yojson {request;nonce} with

--- a/lib/nonce.ml
+++ b/lib/nonce.ml
@@ -1,19 +1,19 @@
-type reader = int Pipe.Reader.t
+type reader = int Inf_pipe.Reader.t
 
 module type S = sig
   type t [@@deriving sexp]
 
-  val pipe : init:t -> unit -> int Pipe.Reader.t Deferred.t
+  val pipe : init:t -> unit -> int Inf_pipe.Reader.t Deferred.t
 end
 
 module Counter : S with type t = int = struct
   type t = int [@@deriving sexp]
   let pipe ~init () =
-    Pipe.unfold ~init
+    Inf_pipe.unfold ~init
       ~f:
         (fun s ->
            let s' = s + 1 in
-           Some (s, s') |> return
+           (s, s') |> return
         )
     |> return
 end
@@ -37,7 +37,7 @@ module File = struct
   let pipe ~init:filename () =
     Cfg.create_config_dir () >>= fun () ->
     create_nonce_file ?default:None filename >>= fun () ->
-    Pipe.unfold ~init:() ~f:
+    Inf_pipe.unfold ~init:() ~f:
       (fun _ ->
          Reader.open_file ?buf_len:None
            filename >>= Reader.really_read_line
@@ -49,7 +49,7 @@ module File = struct
          let nonce' = nonce + 1 in
          Writer.save filename
            ~contents:(sprintf "%d\n" nonce') >>= fun () ->
-         return @@ Some (nonce, ())
+         return (nonce, ())
       ) |> return
 
   let default_filename =
@@ -70,11 +70,9 @@ module Request = struct
     {request:string; nonce:int; payload:Yojson.Safe.t option [@default None]}
 
   let make ~request ~nonce ?payload () =
-    Pipe.read nonce >>= function
-    | `Ok nonce ->
+    Inf_pipe.read nonce >>= fun nonce ->
       return
         {request;nonce;payload}
-    | `Eof -> failwith("Got unexpected EOF from nonce reader")
 
   let to_yojson {request;nonce;payload} : Yojson.Safe.t =
     match request_nonce_to_yojson {request;nonce} with

--- a/lib/order_events.mli
+++ b/lib/order_events.mli
@@ -159,7 +159,7 @@ include Ws.CHANNEL
 val command : string * Async.Command.t
 
 val client :
-  nonce:int Pipe.Reader.t ->
+  nonce:int Inf_pipe.Reader.t ->
   (module Cfg.S) ->
   ?query:Sexp.t list ->
   ?uri_args:uri_args ->


### PR DESCRIPTION
 - Support for `/v1/notionalvolume` api: https://docs.gemini.com/rest-api/#get-notional-volume
 - Introduce `Inf_pipe` to simplify pipe readers which will never experience the `Eof` case.
 - Fix `.ocaminit` load bug to `cohthp-async` package name change.
