### PR TITLE
Add symbol -> currency utils

### DIFF
--- a/lib/common.ml
+++ b/lib/common.ml
@@ -46,51 +46,6 @@ struct
   include (Json.Make(T) : Json.S with type t := t)
 end
 
-
-(** A symbol on the gemini exchange - Symbols are two currency
-    names appended together which can be thought as
-    "Buy the first one, Sell the second one". So [`Btcusd] implies
-    you are buying btc and sell usd, effectively exchanging your
-    currency from usd to btc in the process.
-*)
-module Symbol = struct
-  module T = struct
-    (** The type of a symbol pair. See the [Symbol] module for details. *)
-    type t =
-      [ `Btcusd | `Ethusd | `Ethbtc
-      | `Zecusd | `Zecbtc | `Zeceth | `Zecbch | `Zecltc
-      | `Ltcusd | `Ltcbtc | `Ltceth | `Ltcbch
-      | `Bchusd | `Bchbtc | `Bcheth
-      | `Lunausd | `Xtzusd
-      ]
-    [@@deriving sexp, enumerate, equal, compare]
-
-    let to_string : [<t] -> string = function
-      | `Btcusd -> "btcusd"
-      | `Bchusd -> "bchusd"
-      | `Bchbtc -> "bchbtc"
-      | `Bcheth -> "bcheth"
-      | `Ethusd -> "ethusd"
-      | `Ethbtc -> "ethbtc"
-      | `Zecusd -> "zecusd"
-      | `Zecbtc -> "zecbtc"
-      | `Zeceth -> "zeceth"
-      | `Zecbch -> "zecbch"
-      | `Zecltc -> "zecltc"
-      | `Ltcusd -> "ltcusd"
-      | `Ltcbtc -> "ltcbtc"
-      | `Ltceth -> "ltceth"
-      | `Ltcbch -> "ltcbch"
-      | `Lunausd -> "lunausd"
-      | `Xtzusd -> "xtzusd"
-
-
-  end
-  include T
-  include (Json.Make(T) : Json.S with type t := t)
-
-end
-
 (** Represents an exchange type. Only gemini is currently supported *)
 module Exchange = struct
 
@@ -192,6 +147,74 @@ module Currency = struct
       | `Luna -> "luna"
       | `Xtz -> "xtz"
       | `Ust -> "ust"
+  end
+  include T
+  include (Json.Make(T) : Json.S with type t := t)
+
+end
+
+
+(** A symbol on the gemini exchange - Symbols are two currency
+    names appended together which can be thought as
+    "Buy the first one, Sell the second one". So [`Btcusd] implies
+    you are buying btc and sell usd, effectively exchanging your
+    currency from usd to btc in the process.
+*)
+module Symbol = struct
+  module T = struct
+    (** The type of a symbol pair. See the [Symbol] module for details. *)
+    type t =
+      [ `Btcusd | `Ethusd | `Ethbtc
+      | `Zecusd | `Zecbtc | `Zeceth | `Zecbch | `Zecltc
+      | `Ltcusd | `Ltcbtc | `Ltceth | `Ltcbch
+      | `Bchusd | `Bchbtc | `Bcheth
+      | `Lunausd | `Xtzusd
+      ]
+    [@@deriving sexp, enumerate, equal, compare]
+
+    let to_string : [<t] -> string = function
+      | `Btcusd -> "btcusd"
+      | `Bchusd -> "bchusd"
+      | `Bchbtc -> "bchbtc"
+      | `Bcheth -> "bcheth"
+      | `Ethusd -> "ethusd"
+      | `Ethbtc -> "ethbtc"
+      | `Zecusd -> "zecusd"
+      | `Zecbtc -> "zecbtc"
+      | `Zeceth -> "zeceth"
+      | `Zecbch -> "zecbch"
+      | `Zecltc -> "zecltc"
+      | `Ltcusd -> "ltcusd"
+      | `Ltcbtc -> "ltcbtc"
+      | `Ltceth -> "ltceth"
+      | `Ltcbch -> "ltcbch"
+      | `Lunausd -> "lunausd"
+      | `Xtzusd -> "xtzusd"
+
+    let to_currency_pair : [<t] -> Currency.t * Currency.t = function
+      | `Btcusd -> (`Btc, `Usd)
+      | `Bchusd -> (`Bch, `Usd)
+      | `Bchbtc -> (`Bch, `Btc)
+      | `Bcheth -> (`Bch, `Eth)
+      | `Ethusd -> (`Eth, `Usd)
+      | `Ethbtc -> (`Eth, `Btc)
+      | `Zecusd -> (`Zec, `Usd)
+      | `Zecbtc -> (`Zec, `Btc)
+      | `Zeceth -> (`Zec, `Eth)
+      | `Zecbch -> (`Zec, `Bch)
+      | `Zecltc -> (`Zec, `Ltc)
+      | `Ltcusd -> (`Ltc, `Usd)
+      | `Ltcbtc -> (`Ltc, `Btc)
+      | `Ltceth -> (`Ltc, `Eth)
+      | `Ltcbch -> (`Ltc, `Bch)
+      | `Lunausd -> (`Luna, `Usd)
+      | `Xtzusd -> (`Xtz, `Usd)
+
+    let to_currency : [<t] -> Side.t -> Currency.t = fun t side ->
+        to_currency_pair t |> fun (buy, sell) ->
+            match side with
+            | `Buy -> buy
+            | `Sell -> sell
   end
   include T
   include (Json.Make(T) : Json.S with type t := t)

--- a/lib/gemini.ml
+++ b/lib/gemini.ml
@@ -10,12 +10,12 @@ module Inf_pipe = Inf_pipe
 module V1 = struct
   let path = ["v1"]
   module Side = Side
-  module Symbol = Symbol
   module Exchange = Exchange
   module Timestamp = Timestamp
   module Market_data = Market_data
   module Order_events = Order_events
   module Currency = Currency
+  module Symbol = Symbol
   module Order_type = Order_type
 
   module Heartbeat = struct


### PR DESCRIPTION
Adds two functions in the `Symbol` module to convert a `Symbol.t`  to `Currency.t` pairs or a currency given a `Side.t` of the trade.
