### PR TITLE
Api updates

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,0 +1,2 @@
+profile = default
+version = 0.25.1

--- a/app/cli.ml
+++ b/app/cli.ml
@@ -1,3 +1,3 @@
 open Gemini
 let () =
- Command.run V1.command
+ Command_unix.run V1.command

--- a/gemini.opam
+++ b/gemini.opam
@@ -15,9 +15,10 @@ build: [
 ]
 doc: "https://struktured.github.io/ocaml-gemini/"
 depends: [
-  "ocaml" {>= "4.06.1"}
-  "async" {>= "v0.11.0"}
-  "core" {>= "v0.11.1"}
+  "ocaml" {>= "5.1.0"}
+  "async" {>= "v0.16.0"}
+  "core" {>= "v0.16.1"}
+  "core_unix" {>= "v0.16.0"}
   "async_ssl"
   "cohttp-async"
   "dune" {build}
@@ -31,5 +32,4 @@ depends: [
   "ppx_csv_conv"
   "csvfields"
   "websocket-async"
-  "expect_test_helpers"
 ]

--- a/lib/auth.ml
+++ b/lib/auth.ml
@@ -1,32 +1,30 @@
+type t = [ `Base64 of Cstruct.t | Hex.t ]
 (** An authentication token type. *)
-type t = [`Base64 of Cstruct.t | Hex.t]
-
 
 (** Given a base64 payload, produce an authentication token. *)
-let of_payload s : [< t > `Base64] = `Base64
-    (Cstruct.of_string s |> Nocrypto.Base64.encode)
+let of_payload s : [< t > `Base64 ] =
+  `Base64 (Cstruct.of_string s |> Nocrypto.Base64.encode)
 
-let hmac_sha384 ~api_secret (`Base64 payload) : [< t > `Hex] =
+let hmac_sha384 ~api_secret (`Base64 payload) : [< t > `Hex ] =
   let key = Cstruct.of_string api_secret in
-  Nocrypto.Hash.SHA384.hmac ~key payload
-  |> Hex.of_cstruct
+  Nocrypto.Hash.SHA384.hmac ~key payload |> Hex.of_cstruct
 
 (** Produce a string representation of the authentication token. *)
-let to_string : [<t] -> string = function
+let to_string : [< t ] -> string = function
   | `Base64 cstruct -> Cstruct.to_string cstruct
   | `Hex hex -> hex
 
 (** Encode an authentication token as a gemini payload with
     an http header encoding. Use module [Cfg] to determine
     secrets and the api target. *)
-let to_headers (module Cfg:Cfg.S) t =
+let to_headers (module Cfg : Cfg.S) t =
   Cohttp.Header.of_list
-    ["Content-Type", "text/plain";
-     "Content-Length", "0";
-     "Cache-Control", "no-cache";
-     "X-GEMINI-PAYLOAD", to_string t;
-     "X-GEMINI-APIKEY", Cfg.api_key;
-     "X-GEMINI-SIGNATURE",
-     hmac_sha384 ~api_secret:Cfg.api_secret t |>
-     to_string
+    [
+      ("Content-Type", "text/plain");
+      ("Content-Length", "0");
+      ("Cache-Control", "no-cache");
+      ("X-GEMINI-PAYLOAD", to_string t);
+      ("X-GEMINI-APIKEY", Cfg.api_key);
+      ( "X-GEMINI-SIGNATURE",
+        hmac_sha384 ~api_secret:Cfg.api_secret t |> to_string );
     ]

--- a/lib/common.ml
+++ b/lib/common.ml
@@ -83,9 +83,12 @@ module Timestamp = struct
           Result.Error
             (sprintf "expected float as json but got %S"
                (Yojson.Safe.pretty_to_string json))
-      | `Ok f -> span_fn f |> Time_float_unix.of_span_since_epoch |> fun ok -> Result.Ok ok
+      | `Ok f ->
+          span_fn f |> Time_float_unix.of_span_since_epoch |> fun ok ->
+          Result.Ok ok
 
-    let of_yojson (ms : Yojson.Safe.t) = of_yojson_with_span Time_float_unix.Span.of_ms ms
+    let of_yojson (ms : Yojson.Safe.t) =
+      of_yojson_with_span Time_float_unix.Span.of_ms ms
 
     let of_string s =
       of_yojson (`String s) |> function

--- a/lib/common.ml
+++ b/lib/common.ml
@@ -62,12 +62,13 @@ end
     by various gemini endpoints. *)
 module Timestamp = struct
   module T0 = struct
-    type t = Time.t [@@deriving sexp, equal, compare]
+    type t = Time_float_unix.t [@@deriving sexp, equal, compare]
     (** A timestamp is just a core time instance that
         was converted from some raw json date. *)
 
     let to_string t =
-      Time.to_span_since_epoch t |> Time.Span.to_ms |> Float.to_string
+      Time_float_unix.to_span_since_epoch t
+      |> Time_float_unix.Span.to_ms |> Float.to_string
 
     let to_yojson t = to_string t |> fun s -> `String s
 
@@ -82,9 +83,9 @@ module Timestamp = struct
           Result.Error
             (sprintf "expected float as json but got %S"
                (Yojson.Safe.pretty_to_string json))
-      | `Ok f -> span_fn f |> Time.of_span_since_epoch |> fun ok -> Result.Ok ok
+      | `Ok f -> span_fn f |> Time_float_unix.of_span_since_epoch |> fun ok -> Result.Ok ok
 
-    let of_yojson (ms : Yojson.Safe.t) = of_yojson_with_span Time.Span.of_ms ms
+    let of_yojson (ms : Yojson.Safe.t) = of_yojson_with_span Time_float_unix.Span.of_ms ms
 
     let of_string s =
       of_yojson (`String s) |> function
@@ -108,7 +109,7 @@ module Timestamp = struct
     include T
 
     let of_yojson (sec : Yojson.Safe.t) =
-      of_yojson_with_span Time.Span.of_sec sec
+      of_yojson_with_span Time_float_unix.Span.of_sec sec
 
     let to_yojson (sec : t) = to_yojson sec
   end

--- a/lib/csv_support.ml
+++ b/lib/csv_support.ml
@@ -3,122 +3,117 @@
 module Optional = struct
   module type ARGS = sig
     type t [@@deriving sexp, yojson]
+
     include Csvfields.Csv.Stringable with type t := t
 
     val null : string
   end
 
-  module Default_args
-      (Args : sig
-         type t [@@deriving sexp, yojson]
-         include Csvfields.Csv.Stringable with type t := t
-       end) : ARGS with type t = Args.t =
-  struct
+  module Default_args (Args : sig
+    type t [@@deriving sexp, yojson]
+
+    include Csvfields.Csv.Stringable with type t := t
+  end) : ARGS with type t = Args.t = struct
     let null = ""
+
     include Args
   end
 
-  module type S =
-  sig
+  module type S = sig
     type elt [@@deriving sexp, yojson]
     type t = elt option [@@deriving sexp, yojson]
+
     include Csvfields.Csv.Csvable with type t := t
   end
 
-  module Make(C:ARGS) : S with type elt = C.t =
-  struct
-
+  module Make (C : ARGS) : S with type elt = C.t = struct
     type elt = C.t [@@deriving sexp, yojson]
+
     module T = struct
       type t = elt option [@@deriving sexp, yojson]
-      let to_string t =
-        Option.value_map ~default:C.null t ~f:C.to_string
+
+      let to_string t = Option.value_map ~default:C.null t ~f:C.to_string
+
       let of_string s =
         if String.equal C.null s then None else Some (C.of_string s)
     end
+
     include T
-    include (Csvfields.Csv.Atom(T) : Csvfields.Csv.Csvable with type t := t)
+    include (Csvfields.Csv.Atom (T) : Csvfields.Csv.Csvable with type t := t)
   end
 
-  module Make_default
-      (Args : sig
-         type t [@@deriving sexp, yojson]
-         include Csvfields.Csv.Stringable with type t := t
-       end) =
-   Make(Default_args(Args))
+  module Make_default (Args : sig
+    type t [@@deriving sexp, yojson]
 
+    include Csvfields.Csv.Stringable with type t := t
+  end) =
+    Make (Default_args (Args))
 
-  module String =
-    Make_default(
-    struct
-      type t = string [@@deriving yojson]
-      include (String : module type of String with type t := t)
-    end
-    )
+  module String = Make_default (struct
+    type t = string [@@deriving yojson]
+
+    include (String : module type of String with type t := t)
+  end)
 end
-
 
 module List = struct
   module type ARGS = sig
     type t [@@deriving sexp, yojson]
+
     include Csvfields.Csv.Stringable with type t := t
+
     val sep : char
   end
 
-  module Default_args
-      (Args : sig
-         type t [@@deriving sexp, yojson]
-         include Csvfields.Csv.Stringable with type t := t
-       end) =
+  module Default_args (Args : sig
+    type t [@@deriving sexp, yojson]
+
+    include Csvfields.Csv.Stringable with type t := t
+  end) =
   struct
     let sep = ' '
+
     include Args
   end
 
-  module type S =
-  sig
+  module type S = sig
     type elt [@@deriving sexp, yojson]
     type t = elt list [@@deriving sexp, yojson]
+
     include Csvfields.Csv.Csvable with type t := t
   end
 
-  module Make(C:ARGS) : S with type elt = C.t =
-  struct
-
+  module Make (C : ARGS) : S with type elt = C.t = struct
     type elt = C.t [@@deriving sexp, yojson]
+
     module T = struct
       type t = elt list [@@deriving sexp, yojson]
+
       let to_string t =
         List.map ~f:C.to_string t |> String.concat ~sep:(Char.to_string C.sep)
-      let of_string s =
-        String.split ~on:C.sep s |> List.map ~f:C.of_string
+
+      let of_string s = String.split ~on:C.sep s |> List.map ~f:C.of_string
     end
+
     include T
-    include (Csvfields.Csv.Atom(T) : Csvfields.Csv.Csvable with type t := t)
+    include (Csvfields.Csv.Atom (T) : Csvfields.Csv.Csvable with type t := t)
   end
 
-  module Make_default
-      (Args : sig
-         type t [@@deriving sexp, yojson]
-         include Csvfields.Csv.Stringable with type t := t
-       end) =
-   Make(Default_args(Args))
+  module Make_default (Args : sig
+    type t [@@deriving sexp, yojson]
 
-   module String =
-    Make
-      (Default_args(
-        struct
-          type t = string [@@deriving yojson]
-          include (String : module type of String with type t := t)
-        end
-        )
-      )
+    include Csvfields.Csv.Stringable with type t := t
+  end) =
+    Make (Default_args (Args))
 
+  module String = Make (Default_args (struct
+    type t = string [@@deriving yojson]
+
+    include (String : module type of String with type t := t)
+  end))
 end
 
 let write_header out header =
   let s = sprintf "%s\n" (String.concat ~sep:"," header) in
   Log.Global.debug "csv_support: writing header: %s" s;
   Out_channel.output_string out s
-
-

--- a/lib/dune
+++ b/lib/dune
@@ -12,6 +12,7 @@
   (libraries
               async
               cohttp-async
+              core_unix.command_unix
               csvfields
               ppx_deriving_yojson.runtime
               ppx_csv_conv

--- a/lib/dune
+++ b/lib/dune
@@ -2,7 +2,7 @@
   (name gemini)
   (public_name gemini)
   (flags
-    :standard -w -39
+    :standard -w -73
     -open Core
     -open Async
   )

--- a/lib/gemini.ml
+++ b/lib/gemini.ml
@@ -1,5 +1,4 @@
 open Common
-
 module Auth = Auth
 module Cfg = Cfg
 module Nonce = Nonce
@@ -8,7 +7,8 @@ module Result = Json.Result
 module Inf_pipe = Inf_pipe
 
 module V1 = struct
-  let path = ["v1"]
+  let path = [ "v1" ]
+
   module Side = Side
   module Exchange = Exchange
   module Timestamp = Timestamp
@@ -21,90 +21,87 @@ module V1 = struct
   module Heartbeat = struct
     module T = struct
       let name = "heartbeat"
-      let path = path@["heartbeat"]
+      let path = path @ [ "heartbeat" ]
+
       type request = unit [@@deriving sexp, yojson]
-      type response = {result:bool [@default true]}
+
+      type response = { result : bool [@default true] }
       [@@deriving sexp, of_yojson]
     end
+
     include T
-    include Rest.Make_no_arg(T)
+    include Rest.Make_no_arg (T)
   end
 
   module Order_execution_option = struct
-
     module T = struct
-      type t =
-        [`Maker_or_cancel
-        |`Immediate_or_cancel
-        |`Auction_only
-        ] [@@deriving sexp, enumerate]
+      type t = [ `Maker_or_cancel | `Immediate_or_cancel | `Auction_only ]
+      [@@deriving sexp, enumerate]
 
       let to_string = function
         | `Maker_or_cancel -> "maker_or_cancel"
         | `Immediate_or_cancel -> "immediate_or_cancel"
         | `Auction_only -> "auction_only"
-
     end
+
     include T
-    include (Json.Make(T) : Json.S with type t:= t)
-
+    include (Json.Make (T) : Json.S with type t := t)
   end
 
+  module Break_type = struct
+    module T = struct
+      type t = [ `Manual | `Full ]
+      [@@deriving sexp, enumerate, hash, equal, yojson]
 
- module Break_type = struct
-   module T = struct
-     type t = [`Manual | `Full] [@@deriving sexp, enumerate, hash, equal, yojson]
-     let to_string = function `Manual -> "manual" | `Full -> "full"
-   end
-   include T
-   include (Json.Make(T) : Json.S with type t:= t)
+      let to_string = function `Manual -> "manual" | `Full -> "full"
+    end
+
+    include T
+    include (Json.Make (T) : Json.S with type t := t)
   end
 
- module Trade = struct
-     type t = {price:Decimal_string.t;
-                  amount:Decimal_string.t;
-                  timestamp:Timestamp.Sec.t;
-                  timestampms:Timestamp.Ms.t;
-                  type_: Side.t [@key "type"];
-                  aggressor: bool;
-                  fee_currency: Currency.t;
-                  fee_amount : Decimal_string.t;
-                  tid:Int_number.t;
-                  order_id : Int_string.t;
-                  client_order_id : Client_order_id.t option [@default None];
-                  is_auction_fill : bool;
-                  is_clearing_fill: bool;
-                  symbol: Symbol.t;
-                  exchange : Exchange.t;
-                  break: Break_type.t option [@default None]
-                 } [@@deriving yojson, sexp]
- end
+  module Trade = struct
+    type t = {
+      price : Decimal_string.t;
+      amount : Decimal_string.t;
+      timestamp : Timestamp.Sec.t;
+      timestampms : Timestamp.Ms.t;
+      type_ : Side.t; [@key "type"]
+      aggressor : bool;
+      fee_currency : Currency.t;
+      fee_amount : Decimal_string.t;
+      tid : Int_number.t;
+      order_id : Int_string.t;
+      client_order_id : Client_order_id.t option; [@default None]
+      is_auction_fill : bool;
+      is_clearing_fill : bool;
+      symbol : Symbol.t;
+      exchange : Exchange.t;
+      break : Break_type.t option; [@default None]
+    }
+    [@@deriving yojson, sexp]
+  end
 
- module Order =
-  struct
+  module Order = struct
     let name = "order"
-    let path = path@["order"]
+    let path = path @ [ "order" ]
 
-    
-    module Status =
-    struct
+    module Status = struct
       module T = struct
         let name = "status"
-        let path = path@["status"]
+        let path = path @ [ "status" ]
 
-        type request = {
-          order_id:Int_number.t;
-        } [@@deriving yojson, sexp]
+        type request = { order_id : Int_number.t } [@@deriving yojson, sexp]
 
         type response = {
-          client_order_id : Client_order_id.t option [@default None];
+          client_order_id : Client_order_id.t option; [@default None]
           order_id : Int_string.t;
           id : Int_string.t;
           symbol : Symbol.t;
           exchange : Exchange.t;
           avg_execution_price : Decimal_string.t;
           side : Side.t;
-          type_ : Order_type.t [@key "type"];
+          type_ : Order_type.t; [@key "type"]
           timestamp : Timestamp.Sec.t;
           timestampms : Timestamp.Ms.t;
           is_live : bool;
@@ -116,236 +113,246 @@ module V1 = struct
           options : Order_execution_option.t list;
           price : Decimal_string.t;
           original_amount : Decimal_string.t;
-          trades: Trade.t list [@default []]
-        } [@@deriving yojson, sexp]
+          trades : Trade.t list; [@default []]
+        }
+        [@@deriving yojson, sexp]
       end
+
       include T
-      include Rest.Make(T)
+      include Rest.Make (T)
     end
 
     module New = struct
       module T = struct
         let name = "new"
-        let path = path@["new"]
+        let path = path @ [ "new" ]
 
         type request = {
-          client_order_id:Client_order_id.t;
-          symbol:Symbol.t;
-          amount:Decimal_string.t;
-          price:Decimal_string.t;
-          side:Side.t;
-          type_:Order_type.t [@key "type"];
-          options: Order_execution_option.t list;
-        } [@@deriving sexp, yojson]
+          client_order_id : Client_order_id.t;
+          symbol : Symbol.t;
+          amount : Decimal_string.t;
+          price : Decimal_string.t;
+          side : Side.t;
+          type_ : Order_type.t; [@key "type"]
+          options : Order_execution_option.t list;
+        }
+        [@@deriving sexp, yojson]
 
         type response = Status.response [@@deriving of_yojson, sexp]
       end
-      include T
-      include Rest.Make(T)
 
+      include T
+      include Rest.Make (T)
     end
 
     module Cancel = struct
       let name = "cancel"
-      let path = path@["cancel"]
+      let path = path @ [ "cancel" ]
 
       module By_order_id = struct
         module T = struct
           let name = "by-order-id"
           let path = path
 
-          type request = {order_id:Int_string.t} [@@deriving sexp, yojson]
-
+          type request = { order_id : Int_string.t } [@@deriving sexp, yojson]
           type response = Status.response [@@deriving sexp, of_yojson]
         end
+
         include T
-        include Rest.Make(T)
+        include Rest.Make (T)
       end
-      type details =
-        {cancelled_orders:Status.response list [@key "cancelledOrders"];
-         cancel_rejects:Status.response list [@key "cancelRejects"]
-        } [@@deriving sexp, yojson]
+
+      type details = {
+        cancelled_orders : Status.response list; [@key "cancelledOrders"]
+        cancel_rejects : Status.response list; [@key "cancelRejects"]
+      }
+      [@@deriving sexp, yojson]
 
       module All = struct
         module T = struct
           let name = "all"
-          let path = path@["all"]
-          type request = unit [@@deriving sexp, yojson]
+          let path = path @ [ "all" ]
 
-          type response = {details:details} [@@deriving sexp, of_yojson]
+          type request = unit [@@deriving sexp, yojson]
+          type response = { details : details } [@@deriving sexp, of_yojson]
         end
+
         include T
-        include Rest.Make_no_arg(T)
+        include Rest.Make_no_arg (T)
       end
 
       module Session = struct
         module T = struct
           let name = "session"
-          let path = path@["session"]
+          let path = path @ [ "session" ]
+
           type request = unit [@@deriving sexp, yojson]
-          type response = {details:details} [@@deriving sexp, of_yojson]
+          type response = { details : details } [@@deriving sexp, of_yojson]
         end
+
         include T
-        include Rest.Make_no_arg(T)
+        include Rest.Make_no_arg (T)
       end
 
       let command : string * Command.t =
-        (name,
-         Command.group
-           ~summary:(Path.to_summary ~has_subnames:true path)
-           [By_order_id.command;
-            Session.command;
-            All.command
-           ]
-        )
+        ( name,
+          Command.group
+            ~summary:(Path.to_summary ~has_subnames:true path)
+            [ By_order_id.command; Session.command; All.command ] )
     end
 
     let command : string * Command.t =
-      (name,
-       Command.group
-         ~summary:(Path.to_summary ~has_subnames:true path)
-         [New.command;
-          Cancel.command;
-          Status.command
-         ]
-      )
-
+      ( name,
+        Command.group
+          ~summary:(Path.to_summary ~has_subnames:true path)
+          [ New.command; Cancel.command; Status.command ] )
   end
 
   module Orders = struct
-
     module T = struct
       let name = "orders"
-      let path = path@["orders"]
+      let path = path @ [ "orders" ]
 
       type request = unit [@@deriving sexp, yojson]
-      type response =
-        Order.Status.response list [@@deriving of_yojson, sexp]
+      type response = Order.Status.response list [@@deriving of_yojson, sexp]
     end
+
     include T
-    include Rest.Make_no_arg(T)
+    include Rest.Make_no_arg (T)
   end
 
   module Mytrades = struct
-   module T = struct
+    module T = struct
       let name = "mytrades"
-      let path = path@["mytrades"]
-      type request =
-        { symbol : Symbol.t;
-          limit_trades: int option [@default None];
-          timestamp: Timestamp.Sec.t option [@default None]
-        } [@@deriving sexp, yojson]
+      let path = path @ [ "mytrades" ]
+
+      type request = {
+        symbol : Symbol.t;
+        limit_trades : int option; [@default None]
+        timestamp : Timestamp.Sec.t option; [@default None]
+      }
+      [@@deriving sexp, yojson]
+
       type response = Trade.t list [@@deriving of_yojson, sexp]
     end
-    include T
-    include Rest.Make(T)
 
+    include T
+    include Rest.Make (T)
   end
 
   module Tradevolume = struct
-
     type volume = {
-       account_id:(Int_number.t option [@default None]);
-       symbol:Symbol.t;
-       base_currency:Currency.t;
-       notional_currency:Currency.t;
-       data_date:string; (*TODO use timestamp or a date module with MMMM-DD-YY *)
-       total_volume_base:Decimal_number.t;
-       maker_buy_sell_ratio:Decimal_number.t;
-       buy_maker_base:Decimal_number.t;
-       buy_maker_notional:Decimal_number.t;
-       buy_maker_count:Int_number.t;
-       sell_maker_base:Decimal_number.t;
-       sell_maker_notional:Decimal_number.t;
-       sell_maker_count:Int_number.t;
-       buy_taker_base:Decimal_number.t;
-       buy_taker_notional:Decimal_number.t;
-       buy_taker_count:Int_number.t;
-       sell_taker_base:Decimal_number.t;
-       sell_taker_notional:Decimal_number.t;
-       sell_taker_count:Int_number.t;
-      } [@@deriving yojson, sexp]
+      account_id : (Int_number.t option[@default None]);
+      symbol : Symbol.t;
+      base_currency : Currency.t;
+      notional_currency : Currency.t;
+      data_date : string;
+          (*TODO use timestamp or a date module with MMMM-DD-YY *)
+      total_volume_base : Decimal_number.t;
+      maker_buy_sell_ratio : Decimal_number.t;
+      buy_maker_base : Decimal_number.t;
+      buy_maker_notional : Decimal_number.t;
+      buy_maker_count : Int_number.t;
+      sell_maker_base : Decimal_number.t;
+      sell_maker_notional : Decimal_number.t;
+      sell_maker_count : Int_number.t;
+      buy_taker_base : Decimal_number.t;
+      buy_taker_notional : Decimal_number.t;
+      buy_taker_count : Int_number.t;
+      sell_taker_base : Decimal_number.t;
+      sell_taker_notional : Decimal_number.t;
+      sell_taker_count : Int_number.t;
+    }
+    [@@deriving yojson, sexp]
+
     module T = struct
       let name = "tradevolume"
-      let path = path@["tradevolume"]
+      let path = path @ [ "tradevolume" ]
+
       type request = unit [@@deriving yojson, sexp]
       type response = volume list list [@@deriving of_yojson, sexp]
     end
+
     include T
-    include Rest.Make_no_arg(T)
+    include Rest.Make_no_arg (T)
   end
 
   module Balances = struct
-
     module T = struct
       let name = "balances"
-      let path = path@["balances"]
+      let path = path @ [ "balances" ]
 
       type request = unit [@@deriving yojson, sexp]
-      type balance =
-        {currency:Currency.t;
-         amount:Decimal_string.t;
-         available:Decimal_string.t;
-         available_for_withdrawal:Decimal_string.t
-             [@key "availableForWithdrawal"];
-         type_: string [@key "type"]
-        } [@@deriving yojson, sexp]
+
+      type balance = {
+        currency : Currency.t;
+        amount : Decimal_string.t;
+        available : Decimal_string.t;
+        available_for_withdrawal : Decimal_string.t;
+            [@key "availableForWithdrawal"]
+        type_ : string; [@key "type"]
+      }
+      [@@deriving yojson, sexp]
+
       type response = balance list [@@deriving of_yojson, sexp]
     end
 
     include T
-    include Rest.Make_no_arg(T)
+    include Rest.Make_no_arg (T)
   end
 
   module Notional_volume = struct
-
     module T = struct
       let name = "notionalvolume"
-      let path = path@["notionalvolume"]
+      let path = path @ [ "notionalvolume" ]
 
-      type request = {symbol: Symbol.t option [@default None]; account: string option [@default None]} [@@deriving yojson, sexp]
+      type request = {
+        symbol : Symbol.t option; [@default None]
+        account : string option; [@default None]
+      }
+      [@@deriving yojson, sexp]
+
       type notional_1d_volume = {
-          date: string (* TODO use strict date type *);
-          notional_volume: Decimal_number.t;
-      } [@@deriving sexp, yojson]
-      type response =
-          {last_updated_ms: Timestamp.Ms.t;
-           web_maker_fee_bps: Int_number.t;
-           web_taker_fee_bps: Int_number.t;
-           web_auction_fee_bps: Int_number.t;
-           api_maker_fee_bps: Int_number.t;
-           api_taker_fee_bps: Int_number.t;
-           api_auction_fee_bps: Int_number.t;
-           fix_maker_fee_bps: Int_number.t;
-           fix_taker_fee_bps: Int_number.t;
-           fix_auction_fee_bps: Int_number.t;
-           block_maker_fee_bps: Int_number.t;
-           block_taker_fee_bps: Int_number.t;
-           date: string (* TODO use strict date type *);
-           notional_30d_volume: Decimal_number.t;
-           notional_1d_volume: notional_1d_volume list
-          } [@@deriving yojson, sexp]
+        date : string; (* TODO use strict date type *)
+        notional_volume : Decimal_number.t;
+      }
+      [@@deriving sexp, yojson]
+
+      type response = {
+        last_updated_ms : Timestamp.Ms.t;
+        web_maker_fee_bps : Int_number.t;
+        web_taker_fee_bps : Int_number.t;
+        web_auction_fee_bps : Int_number.t;
+        api_maker_fee_bps : Int_number.t;
+        api_taker_fee_bps : Int_number.t;
+        api_auction_fee_bps : Int_number.t;
+        fix_maker_fee_bps : Int_number.t;
+        fix_taker_fee_bps : Int_number.t;
+        fix_auction_fee_bps : Int_number.t;
+        block_maker_fee_bps : Int_number.t;
+        block_taker_fee_bps : Int_number.t;
+        date : string; (* TODO use strict date type *)
+        notional_30d_volume : Decimal_number.t;
+        notional_1d_volume : notional_1d_volume list;
+      }
+      [@@deriving yojson, sexp]
     end
 
     include T
-    include Rest.Make(T)
+    include Rest.Make (T)
   end
 
-
   let command : Command.t =
-    Command.group
-      ~summary:"Gemini Command System"
-      [Heartbeat.command;
-       Order.command;
-       Orders.command;
-       Mytrades.command;
-       Tradevolume.command;
-       Balances.command;
-       Market_data.command;
-       Order_events.command;
-       Notional_volume.command
+    Command.group ~summary:"Gemini Command System"
+      [
+        Heartbeat.command;
+        Order.command;
+        Orders.command;
+        Mytrades.command;
+        Tradevolume.command;
+        Balances.command;
+        Market_data.command;
+        Order_events.command;
+        Notional_volume.command;
       ]
-
-
-
 end

--- a/lib/gemini.mli
+++ b/lib/gemini.mli
@@ -57,13 +57,14 @@ module V1 : sig
     include Json.S with type t := t
   end
 
-  (** Represents different break types when trades are busted *)
+  (** Represents different break types when trades are busted. *)
   module Break_type : sig
     type t = [ `Manual | `Full ] [@@deriving sexp, enumerate, hash, equal]
 
     include Json.S with type t := t
   end
 
+  (** Represents a single trade. *)
   module Trade : sig
     type t = {
       price : Decimal_string.t;

--- a/lib/gemini.mli
+++ b/lib/gemini.mli
@@ -13,7 +13,6 @@
 *)
 
 open Common
-
 module Auth = Auth
 module Cfg = Cfg
 module Nonce = Nonce
@@ -26,22 +25,22 @@ module V1 : sig
   val path : string list
 
   (** Heartbeat REST api operation. *)
-  module Heartbeat :
-    sig
-      type request = unit [@@deriving sexp, of_yojson]
-      type response = { result : bool; } [@@deriving sexp]
-      include Rest.Operation.S
+  module Heartbeat : sig
+    type request = unit [@@deriving sexp, of_yojson]
+    type response = { result : bool } [@@deriving sexp]
+
+    include
+      Rest.Operation.S
         with type request := request
         with type response := response
-      val post :
-        (module Cfg.S) ->
-        Nonce.reader ->
-        request ->
-        [
-        | Rest.Error.post
-        | `Ok of response
-        ] Deferred.t
-    end
+
+    val post :
+      (module Cfg.S) ->
+      Nonce.reader ->
+      request ->
+      [ Rest.Error.post | `Ok of response ] Deferred.t
+  end
+
   module Timestamp : module type of Timestamp
   module Currency : module type of Currency
   module Symbol : module type of Symbol
@@ -50,361 +49,371 @@ module V1 : sig
   module Order_type : module type of Order_type
 
   (** Represents different execution rules for an order. *)
-  module Order_execution_option :
-    sig
+  module Order_execution_option : sig
+    type t = [ `Auction_only | `Immediate_or_cancel | `Maker_or_cancel ]
+    [@@deriving sexp]
+    (** The type of an order execution rule. *)
 
-      (** The type of an order execution rule. *)
-      type t =
-          [ `Auction_only | `Immediate_or_cancel | `Maker_or_cancel ] [@@deriving sexp]
-      include Json.S with type t := t
-    end
-
-
-(** Represents different break types when trades are busted *)
-module Break_type : sig
-     type t = [`Manual | `Full] [@@deriving sexp, enumerate, hash, equal]
-   include Json.S with type t:= t
+    include Json.S with type t := t
   end
 
-module Trade : sig
-     type t = {price:Decimal_string.t;
-                  amount:Decimal_string.t;
-                  timestamp:Timestamp.Sec.t;
-                  timestampms:Timestamp.Ms.t;
-                  type_: Side.t [@key "type"];
-                  aggressor: bool;
-                  fee_currency: Currency.t;
-                  fee_amount : Decimal_string.t;
-                  tid:Int_number.t;
-                  order_id : Int_string.t;
-                  client_order_id : Client_order_id.t option [@default None];
-                  is_auction_fill : bool;
-                  is_clearing_fill: bool;
-                  symbol: Symbol.t;
-                  exchange : Exchange.t;
-                  break: Break_type.t option [@default None]
-                 } [@@deriving of_yojson, sexp]
- end
+  (** Represents different break types when trades are busted *)
+  module Break_type : sig
+    type t = [ `Manual | `Full ] [@@deriving sexp, enumerate, hash, equal]
 
+    include Json.S with type t := t
+  end
+
+  module Trade : sig
+    type t = {
+      price : Decimal_string.t;
+      amount : Decimal_string.t;
+      timestamp : Timestamp.Sec.t;
+      timestampms : Timestamp.Ms.t;
+      type_ : Side.t; [@key "type"]
+      aggressor : bool;
+      fee_currency : Currency.t;
+      fee_amount : Decimal_string.t;
+      tid : Int_number.t;
+      order_id : Int_string.t;
+      client_order_id : Client_order_id.t option; [@default None]
+      is_auction_fill : bool;
+      is_clearing_fill : bool;
+      symbol : Symbol.t;
+      exchange : Exchange.t;
+      break : Break_type.t option; [@default None]
+    }
+    [@@deriving of_yojson, sexp]
+  end
 
   (** Represents an order on the Gemini trading exchange over
       the REST api. *)
-  module Order :
-    sig
+  module Order : sig
+    val name : string
+    val path : string list
+
+    (** Represents the status of an order on the Gemini trading
+          exchange over the REST api. *)
+    module Status : sig
+      type request = { order_id : Int_number.t } [@@deriving sexp, of_yojson]
+
+      type response = {
+        client_order_id : Client_order_id.t option;
+        order_id : Int_string.t;
+        id : Int_string.t;
+        symbol : Symbol.t;
+        exchange : Exchange.t;
+        avg_execution_price : Decimal_string.t;
+        side : Side.t;
+        type_ : Order_type.t;
+        timestamp : Timestamp.Sec.t;
+        timestampms : Timestamp.Ms.t;
+        is_live : bool;
+        is_cancelled : bool;
+        is_hidden : bool;
+        was_forced : bool;
+        executed_amount : Decimal_string.t;
+        remaining_amount : Decimal_string.t;
+        options : Order_execution_option.t list;
+        price : Decimal_string.t;
+        original_amount : Decimal_string.t;
+        trades : Trade.t list;
+      }
+      [@@deriving sexp]
+
+      include
+        Rest.Operation.S
+          with type request := request
+          with type response := response
+
+      val post :
+        (module Cfg.S) ->
+        Nonce.reader ->
+        request ->
+        [ Rest.Error.post | `Ok of response ] Deferred.t
+
+      val command : string * Command.t
+    end
+
+    (** Represents a new order request on the Gemini trading exchange
+          over the REST api. *)
+    module New : sig
+      type request = {
+        client_order_id : Client_order_id.t;
+        symbol : Symbol.t;
+        amount : Decimal_string.t;
+        price : Decimal_string.t;
+        side : Side.t;
+        type_ : Order_type.t;
+        options : Order_execution_option.t list;
+      }
+      [@@deriving sexp, of_yojson]
+
+      type response = Status.response [@@deriving sexp]
+
+      include
+        Rest.Operation.S
+          with type request := request
+          with type response := response
+
+      val post :
+        (module Cfg.S) ->
+        Nonce.reader ->
+        request ->
+        [ Rest.Error.post | `Ok of response ] Deferred.t
+
+      val command : string * Command.t
+    end
+
+    (** Represents order cancellation features on the
+          Gemini trading exchange over the REST api. *)
+    module Cancel : sig
       val name : string
       val path : string list
 
-      (** Represents the status of an order on the Gemini trading
-          exchange over the REST api. *)
-      module Status :
-      sig
-        type request =
-          { order_id : Int_number.t; } [@@deriving sexp, of_yojson]
-       type response = {
-          client_order_id : Client_order_id.t option;
-          order_id : Int_string.t;
-          id : Int_string.t;
-          symbol : Symbol.t;
-          exchange : Exchange.t;
-          avg_execution_price : Decimal_string.t;
-          side : Side.t;
-          type_ : Order_type.t;
-          timestamp : Timestamp.Sec.t;
-          timestampms : Timestamp.Ms.t;
-          is_live : bool;
-          is_cancelled : bool;
-          is_hidden : bool;
-          was_forced : bool;
-          executed_amount : Decimal_string.t;
-          remaining_amount : Decimal_string.t;
-          options : Order_execution_option.t list;
-          price : Decimal_string.t;
-          original_amount : Decimal_string.t;
-          trades: Trade.t list
-        } [@@deriving sexp]
-        include Rest.Operation.S
-          with type request := request
-          with type response := response
+      module By_order_id : sig
+        type request = { order_id : Int_string.t } [@@deriving sexp, of_yojson]
+        type response = Status.response [@@deriving sexp]
+
+        include
+          Rest.Operation.S
+            with type request := request
+            with type response := response
+
         val post :
           (module Cfg.S) ->
           Nonce.reader ->
           request ->
-          [
-            | Rest.Error.post
-            | `Ok of response
-          ] Deferred.t
+          [ Rest.Error.post | `Ok of response ] Deferred.t
+
         val command : string * Command.t
       end
 
-      (** Represents a new order request on the Gemini trading exchange
-          over the REST api. *)
-      module New :
-        sig
-          type request = {
-            client_order_id : Client_order_id.t;
-            symbol : Symbol.t;
-            amount : Decimal_string.t;
-            price : Decimal_string.t;
-            side : Side.t;
-            type_ : Order_type.t;
-            options : Order_execution_option.t list;
-          } [@@deriving sexp, of_yojson]
-          type response = Status.response [@@deriving sexp]
-          include Rest.Operation.S
+      type details = {
+        cancelled_orders : Status.response list;
+        cancel_rejects : Status.response list;
+      }
+      [@@deriving sexp, yojson]
+
+      module All : sig
+        type request = unit [@@deriving sexp, of_yojson]
+        type response = { details : details } [@@deriving sexp]
+
+        include
+          Rest.Operation.S
             with type request := request
             with type response := response
-          val post :
-            (module Cfg.S) ->
-            Nonce.reader ->
-            request ->
-            [
-              | Rest.Error.post
-              | `Ok of response
-            ] Deferred.t
-          val command : string * Command.t
-        end
 
-      (** Represents order cancellation features on the
-          Gemini trading exchange over the REST api. *)
-      module Cancel :
-        sig
-          val name : string
-          val path : string list
-          module By_order_id :
-            sig
-              type request =
-                { order_id : Int_string.t; } [@@deriving sexp, of_yojson]
-              type response = Status.response [@@deriving sexp]
-              include Rest.Operation.S
-                with type request := request
-                with type response := response
-               val post :
-                (module Cfg.S) ->
-                Nonce.reader ->
-                request ->
-                [
-                  | Rest.Error.post
-                  | `Ok of response
-                ] Deferred.t
-              val command : string * Command.t
-            end
-          type details = {
-            cancelled_orders : Status.response list;
-            cancel_rejects : Status.response list;
-          } [@@deriving sexp, yojson]
-          module All :
-            sig
-              type request = unit [@@deriving sexp, of_yojson]
-              type response =
-                { details : details; } [@@deriving sexp]
-              include Rest.Operation.S
-                with type request := request
-                with type response := response
-              val post :
-                (module Cfg.S) ->
-                Nonce.reader ->
-                request ->
-                [
-                  | Rest.Error.post
-                  | `Ok of response
-                ] Deferred.t
-              val command : string * Command.t
-            end
-          module Session :
-            sig
-              type request = unit [@@deriving sexp, of_yojson]
-              type response = { details : details; }
-              [@@deriving sexp]
-              include Rest.Operation.S
-                with type request := request
-                with type response := response
-              val post :
-                (module Cfg.S) ->
-                Nonce.reader ->
-                request ->
-                [
-                  | Rest.Error.post
-                  | `Ok of response
-                ] Deferred.t
-              val command : string * Command.t
-            end
-          val command : string * Command.t
-        end
+        val post :
+          (module Cfg.S) ->
+          Nonce.reader ->
+          request ->
+          [ Rest.Error.post | `Ok of response ] Deferred.t
+
+        val command : string * Command.t
+      end
+
+      module Session : sig
+        type request = unit [@@deriving sexp, of_yojson]
+        type response = { details : details } [@@deriving sexp]
+
+        include
+          Rest.Operation.S
+            with type request := request
+            with type response := response
+
+        val post :
+          (module Cfg.S) ->
+          Nonce.reader ->
+          request ->
+          [ Rest.Error.post | `Ok of response ] Deferred.t
+
+        val command : string * Command.t
+      end
+
       val command : string * Command.t
     end
 
-   (** Gets the status of all open orders on
+    val command : string * Command.t
+  end
+
+  (** Gets the status of all open orders on
        Gemini trading exchange over the REST api. *)
-   module Orders :
-    sig
-      type request = unit [@@deriving sexp, of_yojson]
-      type response = Order.Status.response list [@@deriving sexp]
-      include Rest.Operation.S
+  module Orders : sig
+    type request = unit [@@deriving sexp, of_yojson]
+    type response = Order.Status.response list [@@deriving sexp]
+
+    include
+      Rest.Operation.S
         with type request := request
         with type response := response
-       val post :
-        (module Cfg.S) ->
-        Nonce.reader ->
-        request ->
-        [
-          | Rest.Error.post
-          | `Ok of response
-        ] Deferred.t
-      val command : string * Command.t
-    end
 
-   (** Gets all trades executed by this api user on
+    val post :
+      (module Cfg.S) ->
+      Nonce.reader ->
+      request ->
+      [ Rest.Error.post | `Ok of response ] Deferred.t
+
+    val command : string * Command.t
+  end
+
+  (** Gets all trades executed by this api user on
        Gemini trading exchange over the REST api. *)
-   module Mytrades :
-    sig
+  module Mytrades : sig
+    type request = {
+      symbol : Symbol.t;
+      limit_trades : int option;
+      timestamp : Timestamp.Sec.t option;
+    }
+    [@@deriving sexp, of_yojson]
+    (** Trade request parameters. *)
 
-      (** Trade request parameters. *)
-      type request = {
-        symbol : Symbol.t;
-        limit_trades : int option;
-        timestamp : Timestamp.Sec.t option;
-      } [@@deriving sexp, of_yojson]
+    type response = Trade.t list [@@deriving sexp]
+    (** Mytrades repsonse type- the type of a list trades. *)
 
-
-      (** Mytrades repsonse type- the type of a list trades. *)
-      type response = Trade.t list [@@deriving sexp]
-
-      include Rest.Operation.S
+    include
+      Rest.Operation.S
         with type request := request
         with type response := response
-       val post :
-        (module Cfg.S) ->
-        Nonce.reader ->
-        request ->
-        [
-          | Rest.Error.post
-          | `Ok of response
-        ] Deferred.t
-      val command : string * Command.t
-    end
-  
+
+    val post :
+      (module Cfg.S) ->
+      Nonce.reader ->
+      request ->
+      [ Rest.Error.post | `Ok of response ] Deferred.t
+
+    val command : string * Command.t
+  end
+
   (** Gets all trade volume executed by on the
       Gemini trading exchange over the REST api. *)
-  module Tradevolume :
-    sig
-
-      (** The type of a trade volume entity for
+  module Tradevolume : sig
+    type volume = {
+      account_id : Int_number.t option;
+      symbol : Symbol.t;
+      base_currency : Currency.t;
+      notional_currency : Currency.t;
+      data_date : string;
+      total_volume_base : Decimal_number.t;
+      maker_buy_sell_ratio : Decimal_number.t;
+      buy_maker_base : Decimal_number.t;
+      buy_maker_notional : Decimal_number.t;
+      buy_maker_count : Int_number.t;
+      sell_maker_base : Decimal_number.t;
+      sell_maker_notional : Decimal_number.t;
+      sell_maker_count : Int_number.t;
+      buy_taker_base : Decimal_number.t;
+      buy_taker_notional : Decimal_number.t;
+      buy_taker_count : Int_number.t;
+      sell_taker_base : Decimal_number.t;
+      sell_taker_notional : Decimal_number.t;
+      sell_taker_count : Int_number.t;
+    }
+    [@@deriving sexp, yojson]
+    (** The type of a trade volume entity for
           one particular symbol on the Gemini trading exchange.
       *)
-      type volume = {
-        account_id : Int_number.t option;
-        symbol : Symbol.t;
-        base_currency : Currency.t;
-        notional_currency : Currency.t;
-        data_date : string;
-        total_volume_base : Decimal_number.t;
-        maker_buy_sell_ratio : Decimal_number.t;
-        buy_maker_base : Decimal_number.t;
-        buy_maker_notional : Decimal_number.t;
-        buy_maker_count : Int_number.t;
-        sell_maker_base : Decimal_number.t;
-        sell_maker_notional : Decimal_number.t;
-        sell_maker_count : Int_number.t;
-        buy_taker_base : Decimal_number.t;
-        buy_taker_notional : Decimal_number.t;
-        buy_taker_count : Int_number.t;
-        sell_taker_base : Decimal_number.t;
-        sell_taker_notional : Decimal_number.t;
-        sell_taker_count : Int_number.t;
-      } [@@deriving sexp, yojson]
-      type request = unit [@@deriving sexp, of_yojson]
 
-      (** The type of a trade volume response, which is a list of list
+    type request = unit [@@deriving sexp, of_yojson]
+
+    type response = volume list list [@@deriving sexp]
+    (** The type of a trade volume response, which is a list of list
           of volumes grouped by exchange symbol. *)
-      type response = volume list list [@@deriving sexp]
 
-      include Rest.Operation.S
+    include
+      Rest.Operation.S
         with type request := request
         with type response := response
-       val post :
-        (module Cfg.S) ->
-        Nonce.reader ->
-        request ->
-        [
-          | Rest.Error.post
-          | `Ok of response
-        ] Deferred.t
-      val command : string * Command.t
-    end
 
-   (** Gets all balances for this api user on the
+    val post :
+      (module Cfg.S) ->
+      Nonce.reader ->
+      request ->
+      [ Rest.Error.post | `Ok of response ] Deferred.t
+
+    val command : string * Command.t
+  end
+
+  (** Gets all balances for this api user on the
        Gemini trading exchange over the REST api. *)
-   module Balances :
-    sig
+  module Balances : sig
+    type request = unit [@@deriving sexp, of_yojson]
+    (** Balance queries have no request parameters. *)
 
-      (** Balance queries have no request parameters. *)
-      type request = unit [@@deriving sexp, of_yojson]
+    type balance = {
+      currency : Currency.t;
+      amount : Decimal_string.t;
+      available : Decimal_string.t;
+      available_for_withdrawal : Decimal_string.t;
+      type_ : string;
+    }
+    [@@deriving sexp, yojson]
+    (** The type of a balance for one specific currency. *)
 
-      (** The type of a balance for one specific currency. *)
-      type balance =
-      {
-        currency : Currency.t;
-        amount : Decimal_string.t;
-        available : Decimal_string.t;
-        available_for_withdrawal : Decimal_string.t;
-        type_ : string;
-      } [@@deriving sexp, yojson]
+    (* A list of balances, one for each supported currency. *)
+    type response = balance list [@@deriving sexp]
 
-      (* A list of balances, one for each supported currency. *)
-      type response = balance list [@@deriving sexp]
-      include Rest.Operation.S
+    include
+      Rest.Operation.S
         with type request := request
         with type response := response
-       val post :
-        (module Cfg.S) ->
-        Nonce.reader ->
-        request ->
-        [
-          | Rest.Error.post
-          | `Ok of response
-        ] Deferred.t
-      val command : string * Command.t
-    end
 
-module Notional_volume :
-    sig
+    val post :
+      (module Cfg.S) ->
+      Nonce.reader ->
+      request ->
+      [ Rest.Error.post | `Ok of response ] Deferred.t
 
-      type request = {symbol: Symbol.t option [@default None]; account: string option [@default None]} [@@deriving of_yojson, sexp]
-      type notional_1d_volume = {
-          date: string (* TODO use strict date type *);
-          notional_volume: Decimal_number.t;
-      } [@@deriving sexp, yojson]
-      type response =
-          {last_updated_ms: Timestamp.Ms.t;
-           web_maker_fee_bps: Int_number.t;
-           web_taker_fee_bps: Int_number.t;
-           web_auction_fee_bps: Int_number.t;
-           api_maker_fee_bps: Int_number.t;
-           api_taker_fee_bps: Int_number.t;
-           api_auction_fee_bps: Int_number.t;
-           fix_maker_fee_bps: Int_number.t;
-           fix_taker_fee_bps: Int_number.t;
-           fix_auction_fee_bps: Int_number.t;
-           block_maker_fee_bps: Int_number.t;
-           block_taker_fee_bps: Int_number.t;
-           date: string (* TODO use strict date type *);
-           notional_30d_volume: Decimal_number.t;
-           notional_1d_volume: notional_1d_volume list
-          } [@@deriving sexp]
-      include Rest.Operation.S
+    val command : string * Command.t
+  end
+
+  module Notional_volume : sig
+    type request = {
+      symbol : Symbol.t option; [@default None]
+      account : string option; [@default None]
+    }
+    [@@deriving of_yojson, sexp]
+
+    type notional_1d_volume = {
+      date : string; (* TODO use strict date type *)
+      notional_volume : Decimal_number.t;
+    }
+    [@@deriving sexp, yojson]
+
+    type response = {
+      last_updated_ms : Timestamp.Ms.t;
+      web_maker_fee_bps : Int_number.t;
+      web_taker_fee_bps : Int_number.t;
+      web_auction_fee_bps : Int_number.t;
+      api_maker_fee_bps : Int_number.t;
+      api_taker_fee_bps : Int_number.t;
+      api_auction_fee_bps : Int_number.t;
+      fix_maker_fee_bps : Int_number.t;
+      fix_taker_fee_bps : Int_number.t;
+      fix_auction_fee_bps : Int_number.t;
+      block_maker_fee_bps : Int_number.t;
+      block_taker_fee_bps : Int_number.t;
+      date : string; (* TODO use strict date type *)
+      notional_30d_volume : Decimal_number.t;
+      notional_1d_volume : notional_1d_volume list;
+    }
+    [@@deriving sexp]
+
+    include
+      Rest.Operation.S
         with type request := request
         with type response := response
-       val post :
-        (module Cfg.S) ->
-        Nonce.reader ->
-        request ->
-        [
-          | Rest.Error.post
-          | `Ok of response
-        ] Deferred.t
-      val command : string * Command.t
+
+    val post :
+      (module Cfg.S) ->
+      Nonce.reader ->
+      request ->
+      [ Rest.Error.post | `Ok of response ] Deferred.t
+
+    val command : string * Command.t
   end
 
   module Market_data = Market_data
+
   val command : Command.t
 end

--- a/lib/gemini.mli
+++ b/lib/gemini.mli
@@ -59,6 +59,34 @@ module V1 : sig
       include Json.S with type t := t
     end
 
+
+(** Represents different break types when trades are busted *)
+module Break_type : sig
+     type t = [`Manual | `Full] [@@deriving sexp, enumerate, hash, equal]
+   include Json.S with type t:= t
+  end
+
+module Trade : sig
+     type t = {price:Decimal_string.t;
+                  amount:Decimal_string.t;
+                  timestamp:Timestamp.Sec.t;
+                  timestampms:Timestamp.Ms.t;
+                  type_: Side.t [@key "type"];
+                  aggressor: bool;
+                  fee_currency: Currency.t;
+                  fee_amount : Decimal_string.t;
+                  tid:Int_number.t;
+                  order_id : Int_string.t;
+                  client_order_id : Client_order_id.t option [@default None];
+                  is_auction_fill : bool;
+                  is_clearing_fill: bool;
+                  symbol: Symbol.t;
+                  exchange : Exchange.t;
+                  break: Break_type.t option [@default None]
+                 } [@@deriving of_yojson, sexp]
+ end
+
+
   (** Represents an order on the Gemini trading exchange over
       the REST api. *)
   module Order :
@@ -92,6 +120,7 @@ module V1 : sig
           options : Order_execution_option.t list;
           price : Decimal_string.t;
           original_amount : Decimal_string.t;
+          trades: Trade.t list
         } [@@deriving sexp]
         include Rest.Operation.S
           with type request := request
@@ -229,26 +258,6 @@ module V1 : sig
    module Mytrades :
     sig
 
-      (** Represents one instance of a trade exchanged on Gemini. *)
-      type trade = {
-        price : Decimal_string.t;
-        amount : Decimal_string.t;
-        timestamp : Timestamp.Sec.t;
-        timestampms : Timestamp.Ms.t;
-        type_ : Side.t;
-        aggressor : bool;
-        fee_currency : Currency.t;
-        fee_amount : Decimal_string.t;
-        tid : Int_number.t;
-        order_id : Int_string.t;
-        client_order_id : Client_order_id.t option;
-        is_auction_fill : bool;
-        is_clearing_fill: bool;
-        symbol: Symbol.t;
-        exchange : Exchange.t;
-      } [@@deriving sexp, yojson]
-
-
       (** Trade request parameters. *)
       type request = {
         symbol : Symbol.t;
@@ -258,7 +267,7 @@ module V1 : sig
 
 
       (** Mytrades repsonse type- the type of a list trades. *)
-      type response = trade list [@@deriving sexp]
+      type response = Trade.t list [@@deriving sexp]
 
       include Rest.Operation.S
         with type request := request

--- a/lib/gemini.mli
+++ b/lib/gemini.mli
@@ -415,6 +415,7 @@ module V1 : sig
   end
 
   module Market_data = Market_data
+  module Order_events = Order_events
 
   val command : Command.t
 end

--- a/lib/inf_pipe.ml
+++ b/lib/inf_pipe.ml
@@ -1,82 +1,107 @@
 open Async
 
 module T = struct
-
-module Reader = struct
+  module Reader = struct
     type 'a t = 'a Pipe.Reader.t
-    let create (reader: 'a Pipe.Reader.t ) : 'a t = reader
-end 
 
-module Writer = struct
+    let create (reader : 'a Pipe.Reader.t) : 'a t = reader
+  end
+
+  module Writer = struct
     type 'a t = 'a Pipe.Writer.t
+
     let create (writer : 'a Pipe.Writer.t) : 'a t = writer
-end
+  end
 
+  let create = Pipe.create
 
-let create = Pipe.create
-let read ?consumer t =
+  let read ?consumer t =
     Pipe.read ?consumer t >>| function `Ok x -> x | `Eof -> assert false
 
-let read_now ?consumer t =
+  let read_now ?consumer t =
     Pipe.read_now ?consumer t |> function
     | `Ok _ as ok -> ok
     | `Nothing_available as na -> na
     | `Eof -> assert false
 
-let read_exactly ?consumer t ~num_values =
-      Pipe.read_exactly ?consumer t ~num_values >>| function | `Exactly e -> e | `Fewer _ | `Eof -> assert false
+  let read_exactly ?consumer t ~num_values =
+    Pipe.read_exactly ?consumer t ~num_values >>| function
+    | `Exactly e -> e
+    | `Fewer _ | `Eof -> assert false
 
-let to_pipe t : 'a Pipe.Reader.t = t
+  let to_pipe t : 'a Pipe.Reader.t = t
+  let interleave l = Pipe.interleave l |> Reader.create
 
-let interleave l = Pipe.interleave l |> Reader.create
-
-let unfold ~init ~f : 'a Reader.t =
+  let unfold ~init ~f : 'a Reader.t =
     Pipe.unfold ~init ~f:(fun (acc : 's) ->
         f acc >>| fun (acc, s) -> Some (acc, s))
 
-let map = Pipe.map
-let filter_map = Pipe.filter_map
-
-let folding_map = Pipe.folding_map
-let folding_filter_map = Pipe.folding_filter_map
-let folding_filter_map'= Pipe.folding_filter_map'
-
-
-let transfer = Pipe.transfer
-
+  let map = Pipe.map
+  let filter_map = Pipe.filter_map
+  let folding_map = Pipe.folding_map
+  let folding_filter_map = Pipe.folding_filter_map
+  let folding_filter_map' = Pipe.folding_filter_map'
+  let transfer = Pipe.transfer
 end
-module type S = sig
 
-  module Reader: sig
+module type S = sig
+  module Reader : sig
     type 'a t = private 'a Pipe.Reader.t
-    val create : 'a Pipe.Reader.t  -> 'a t 
+
+    val create : 'a Pipe.Reader.t -> 'a t
   end
 
   module Writer : sig
     type 'a t = private 'a Pipe.Writer.t
-    val create : 'a Pipe.Writer.t  -> 'a t 
+
+    val create : 'a Pipe.Writer.t -> 'a t
   end
 
-  val create: ?info:Sexp.t -> unit -> 'a Reader.t * 'a Writer.t
+  val create : ?info:Sexp.t -> unit -> 'a Reader.t * 'a Writer.t
   val read : ?consumer:Pipe.Consumer.t -> 'a Reader.t -> 'a Deferred.t
+
   val read_now :
     ?consumer:Pipe.Consumer.t ->
-    'a Reader.t -> [> `Nothing_available | `Ok of 'a ]
+    'a Reader.t ->
+    [> `Nothing_available | `Ok of 'a ]
+
   val read_exactly :
     ?consumer:Pipe.Consumer.t ->
-    'a Reader.t -> num_values:int -> 'a Base.Queue.t Deferred.t
+    'a Reader.t ->
+    num_values:int ->
+    'a Base.Queue.t Deferred.t
+
   val unfold : init:'s -> f:('s -> ('a * 's) Deferred.t) -> 'a Reader.t
   val map : 'a Reader.t -> f:('a -> 'b) -> 'b Reader.t
+
   val filter_map :
-     ?max_queue_length:int -> 'a Reader.t -> f:('a -> 'b option) -> 'b Reader.t
+    ?max_queue_length:int -> 'a Reader.t -> f:('a -> 'b option) -> 'b Reader.t
 
   val interleave : 'a Reader.t list -> 'a Reader.t
   val to_pipe : 'a Reader.t -> 'a Pipe.Reader.t
 
-  val folding_map : ?max_queue_length:int -> 'a Reader.t -> init:'accum -> f:('accum -> 'a -> ('accum * 'c)) -> 'c Reader.t
-  val folding_filter_map : ?max_queue_length:int -> 'a Reader.t -> init:'accum -> f:('accum -> 'a -> 'accum * ('c option)) -> 'c Reader.t
-  val folding_filter_map' : ?max_queue_length:int -> 'a Reader.t -> init:'accum -> f:('accum -> 'a -> ('accum * ('c option)) Deferred.t) -> 'c Reader.t
-  val transfer: 'a Reader.t -> 'b Writer.t -> f:('a -> 'b) -> unit Deferred.t
+  val folding_map :
+    ?max_queue_length:int ->
+    'a Reader.t ->
+    init:'accum ->
+    f:('accum -> 'a -> 'accum * 'c) ->
+    'c Reader.t
+
+  val folding_filter_map :
+    ?max_queue_length:int ->
+    'a Reader.t ->
+    init:'accum ->
+    f:('accum -> 'a -> 'accum * 'c option) ->
+    'c Reader.t
+
+  val folding_filter_map' :
+    ?max_queue_length:int ->
+    'a Reader.t ->
+    init:'accum ->
+    f:('accum -> 'a -> ('accum * 'c option) Deferred.t) ->
+    'c Reader.t
+
+  val transfer : 'a Reader.t -> 'b Writer.t -> f:('a -> 'b) -> unit Deferred.t
 end
 
 include (T : S)

--- a/lib/inf_pipe.ml
+++ b/lib/inf_pipe.ml
@@ -57,7 +57,9 @@ module type S = sig
     val create : 'a Pipe.Writer.t -> 'a t
   end
 
-  val create : ?info:Sexp.t -> unit -> 'a Reader.t * 'a Writer.t
+  val create :
+    ?size_budget:int -> ?info:Sexp.t -> unit -> 'a Reader.t * 'a Writer.t
+
   val read : ?consumer:Pipe.Consumer.t -> 'a Reader.t -> 'a Deferred.t
 
   val read_now :

--- a/lib/json.ml
+++ b/lib/json.ml
@@ -1,6 +1,5 @@
 (** Json utility functions. *)
 
-
 (** Result specification when deserializing raw
     json into something strongly in typed ocaml.
   *)
@@ -10,20 +9,18 @@ module Result = struct
   (** Unify results into tuple [('a , 'b)] if both are ok,
       otherwise produce one of the errors .
   *)
-  let both x y : (('a * 'b), 'error) t =
+  let both x y : ('a * 'b, 'error) t =
     match x with
-    | Result.Ok x ->
-      (match y with
-       | Result.Ok y -> Result.Ok (x,y)
-       | Result.Error _ as e -> e
-      )
+    | Result.Ok x -> (
+        match y with
+        | Result.Ok y -> Result.Ok (x, y)
+        | Result.Error _ as e -> e)
     | Result.Error _ as e -> e
-
 end
-
 
 module type S = sig
   type t [@@deriving yojson, enumerate]
+
   val dict : (string * t) list
   val of_string_opt : string -> t option
   val error_message : string -> string
@@ -31,78 +28,71 @@ module type S = sig
   val to_string : t -> string
   val is_csv_atom : bool
   val rev_csv_header' : string list -> 'a -> 'b -> string list
+
   val rev_csv_header_spec' :
-    Csvfields.Csv.Spec.t list ->
-    'a -> 'b -> Csvfields.Csv.Spec.t list
+    Csvfields.Csv.Spec.t list -> 'a -> 'b -> Csvfields.Csv.Spec.t list
+
   val t_of_row' : 'a -> string list -> (unit -> t) * string list
+
   val write_row_of_t' :
     is_first:bool ->
-    is_last:bool -> writer:(string -> unit) -> 'a -> 'b -> t -> unit
+    is_last:bool ->
+    writer:(string -> unit) ->
+    'a ->
+    'b ->
+    t ->
+    unit
+
   val csv_header : string list
   val csv_header_spec : Csvfields.Csv.Spec.t list
   val t_of_row : string list -> t
   val row_of_t : t -> string list
   val csv_load : ?separator:char -> string -> t list
   val csv_load_in : ?separator:char -> In_channel.t -> t list
-  val csv_save_fn :
-    ?separator:char -> (string -> unit) -> t list -> unit
-  val csv_save_out :
-    ?separator:char -> Out_channel.t -> t list -> unit
+  val csv_save_fn : ?separator:char -> (string -> unit) -> t list -> unit
+  val csv_save_out : ?separator:char -> Out_channel.t -> t list -> unit
   val csv_save : ?separator:char -> string -> t list -> unit
-  end
+end
 
 (** An enumeration encodable as a json string. *)
 module type ENUM_STRING = sig
   type t [@@deriving enumerate]
+
   val to_string : t -> string
 end
 
 (** Produce json encoders and decoders given an enumerated
     type and its string representations. *)
-module Make(E:ENUM_STRING) : S with type t = E.t = struct
-
+module Make (E : ENUM_STRING) : S with type t = E.t = struct
   module T = struct
-  let dict = List.zip_exn
-      (List.map E.all ~f:E.to_string)
-      E.all
+    let dict = List.zip_exn (List.map E.all ~f:E.to_string) E.all
 
-  let of_string_opt (s:string) : E.t option =
-    List.Assoc.find dict s
-      ~equal:
-        (fun s s' ->
-          String.equal
-            (String.lowercase s)
-            (String.lowercase s')
-        )
+    let of_string_opt (s : string) : E.t option =
+      List.Assoc.find dict s ~equal:(fun s s' ->
+          String.equal (String.lowercase s) (String.lowercase s'))
 
+    let error_message x =
+      sprintf "String %S is not a valid enumeration value. Expected one of %s" x
+        (String.concat ~sep:", " (List.map ~f:fst dict))
 
-  let error_message x =
-    sprintf
-      "String %S is not a valid enumeration value. \
-       Expected one of %s"
-      x (String.concat ~sep:", " (List.map ~f:fst dict))
+    let of_string x =
+      of_string_opt x |> Option.value_exn ~message:(error_message x)
 
+    let to_yojson t = `String (E.to_string t)
 
-  let of_string x = of_string_opt x |> Option.value_exn
-                      ~message:(error_message x)
+    let of_yojson (json : Yojson.Safe.t) =
+      match json with
+      | `String s -> (
+          match of_string_opt s with
+          | Some t -> Result.return t
+          | None -> error_message s |> Result.fail)
+      | #Yojson.Safe.t ->
+          Result.failf "expected json string but got %S"
+            (Yojson.Safe.to_string json)
 
-  let to_yojson t = `String (E.to_string t)
-
-  let of_yojson (json : Yojson.Safe.t) =
-    match json with
-    | `String s ->
-      (match of_string_opt s with
-      | Some t -> Result.return t
-      | None -> error_message s |> Result.fail
-      )
-   | #Yojson.Safe.t ->
-        Result.failf "expected json string but got %S"
-          (Yojson.Safe.to_string json)
-
-  include E
+    include E
   end
+
   include T
-  include (Csvfields.Csv.Atom(T) :
-             Csvfields.Csv.Csvable with type t := t
-          )
+  include (Csvfields.Csv.Atom (T) : Csvfields.Csv.Csvable with type t := t)
 end

--- a/lib/market_data.ml
+++ b/lib/market_data.ml
@@ -1,41 +1,47 @@
 open Common
-module Side =
-struct
+
+module Side = struct
   module Bid_ask = struct
     module T = struct
-      type t = [`Bid | `Ask] [@@deriving sexp, enumerate]
-      let to_string : [<t] -> string = function
+      type t = [ `Bid | `Ask ] [@@deriving sexp, enumerate]
+
+      let to_string : [< t ] -> string = function
         | `Bid -> "bid"
         | `Ask -> "ask"
     end
+
     include T
-    include (Json.Make(T) : Json.S with type t := t)
+    include (Json.Make (T) : Json.S with type t := t)
   end
 
   module Auction = struct
     module T = struct
-      type t = [`Auction] [@@deriving sexp, enumerate]
-      let to_string = function
-          `Auction -> "auction"
+      type t = [ `Auction ] [@@deriving sexp, enumerate]
+
+      let to_string = function `Auction -> "auction"
     end
+
     include T
-    include (Json.Make(T) : Json.S with type t := t)
+    include (Json.Make (T) : Json.S with type t := t)
   end
 
   module T = struct
-    type t = [Bid_ask.t | Auction.t] [@@deriving sexp, enumerate]
-    let to_string : [<t] -> string = function
+    type t = [ Bid_ask.t | Auction.t ] [@@deriving sexp, enumerate]
+
+    let to_string : [< t ] -> string = function
       | #Bid_ask.t as bid_ask -> Bid_ask.to_string bid_ask
       | #Auction.t as auction -> Auction.to_string auction
   end
+
   include T
-  include (Json.Make(T) : Json.S with type t := t)
+  include (Json.Make (T) : Json.S with type t := t)
 end
 
 module T = struct
   let name = "marketdata"
   let version = "v1"
-  let path = v1::["marketdata"]
+  let path = v1 :: [ "marketdata" ]
+
   type uri_args = Symbol.t [@@deriving sexp, yojson, enumerate]
 
   let authentication = `Public
@@ -43,22 +49,23 @@ module T = struct
   let encode_uri_args = Symbol.to_string
 
   type query = unit [@@deriving sexp]
+
   let encode_query _ = failwith "queries not supported"
 
   module Message_type = struct
     module T = struct
-      type t = [`Update | `Heartbeat] [@@deriving sexp, enumerate]
-      let to_string = function
-        | `Update -> "update"
-        | `Heartbeat -> "heartbeat"
+      type t = [ `Update | `Heartbeat ] [@@deriving sexp, enumerate]
+
+      let to_string = function `Update -> "update" | `Heartbeat -> "heartbeat"
     end
+
     include T
-    include (Json.Make(T) : Json.S with type t := t)
+    include (Json.Make (T) : Json.S with type t := t)
   end
 
   module Event_type = struct
     module T = struct
-      type t = [`Trade | `Change | `Auction | `Auction_open | `Block_trade]
+      type t = [ `Trade | `Change | `Auction | `Auction_open | `Block_trade ]
       [@@deriving sexp, enumerate, compare]
 
       let to_string = function
@@ -67,16 +74,16 @@ module T = struct
         | `Auction -> "auction"
         | `Auction_open -> "auction_open"
         | `Block_trade -> "block_trade"
-
     end
+
     include T
-    include Comparable.Make(T)
-    include (Json.Make(T) : Json.S with type t := t)
+    include Comparable.Make (T)
+    include (Json.Make (T) : Json.S with type t := t)
   end
 
   type heartbeat = unit [@@deriving sexp, of_yojson]
 
-(*
+  (*
   let _with_common_headers (type t) ~event_id ~timestamp
       (module T : Csvfields.Csv.Csvable with type t = t) =
     let module TT = struct
@@ -97,44 +104,47 @@ module T = struct
 
   module Reason = struct
     module T = struct
-      type t =
-        [`Place | `Trade | `Cancel | `Initial] [@@deriving sexp, enumerate]
+      type t = [ `Place | `Trade | `Cancel | `Initial ]
+      [@@deriving sexp, enumerate]
+
       let to_string = function
         | `Place -> "place"
         | `Trade -> "trade"
         | `Cancel -> "cancel"
         | `Initial -> "initial"
     end
+
     include T
-    include (Json.Make(T) : Json.S with type t := t)
+    include (Json.Make (T) : Json.S with type t := t)
   end
 
   module Change_event = struct
     module T = struct
-      type t =
-        {price:Decimal_string.t;
-         side:Side.Bid_ask.t;
-         reason:Reason.t;
-         remaining:Decimal_string.t;
-         delta:Decimal_string.t
-        } [@@deriving sexp, of_yojson, fields, csv]
+      type t = {
+        price : Decimal_string.t;
+        side : Side.Bid_ask.t;
+        reason : Reason.t;
+        remaining : Decimal_string.t;
+        delta : Decimal_string.t;
+      }
+      [@@deriving sexp, of_yojson, fields, csv]
     end
 
     module Decorated = struct
-      type t =
-        {event_id:Int_number.t;
-         timestamp:Timestamp.t;
-         price:Decimal_string.t;
-         side:Side.Bid_ask.t;
-         reason:Reason.t;
-         remaining:Decimal_string.t;
-         delta:Decimal_string.t
-        } [@@deriving sexp, of_yojson, fields, csv]
+      type t = {
+        event_id : Int_number.t;
+        timestamp : Timestamp.t;
+        price : Decimal_string.t;
+        side : Side.Bid_ask.t;
+        reason : Reason.t;
+        remaining : Decimal_string.t;
+        delta : Decimal_string.t;
+      }
+      [@@deriving sexp, of_yojson, fields, csv]
 
       let create ~event_id ~timestamp
-          ({ reason; side;price; remaining; delta }:T.t) =
-        {event_id;timestamp;side;reason;remaining;price;delta}
-
+          ({ reason; side; price; remaining; delta } : T.t) =
+        { event_id; timestamp; side; reason; remaining; price; delta }
     end
 
     let to_decorated = Decorated.create
@@ -144,31 +154,32 @@ module T = struct
 
   module Trade_event = struct
     module T = struct
-      type t =
-        {tid:Int_number.t;
-         price:Decimal_string.t;
-         amount:Decimal_string.t;
-         maker_side:Side.t [@key "makerSide"]
-        } [@@deriving of_yojson, sexp, fields, csv]
+      type t = {
+        tid : Int_number.t;
+        price : Decimal_string.t;
+        amount : Decimal_string.t;
+        maker_side : Side.t; [@key "makerSide"]
+      }
+      [@@deriving of_yojson, sexp, fields, csv]
     end
 
     module Decorated = struct
-      type t =
-        {
-         timestamp:Timestamp.t;
-         tid:Int_number.t;
-         price:Decimal_string.t;
-         amount:Decimal_string.t;
-         maker_side:Side.t [@key "makerSide"]
-        } [@@deriving of_yojson, sexp, fields, csv]
+      type t = {
+        timestamp : Timestamp.t;
+        tid : Int_number.t;
+        price : Decimal_string.t;
+        amount : Decimal_string.t;
+        maker_side : Side.t; [@key "makerSide"]
+      }
+      [@@deriving of_yojson, sexp, fields, csv]
 
-       let create ~event_id ~timestamp
-           ({ tid; price; amount; maker_side }:T.t) =
-         match Int64.equal event_id tid with
-         | true ->
-           {timestamp;tid;price;amount;maker_side}
-         | false -> failwith
-             "logical error: event_id and trade id (tid) should be equal"
+      let create ~event_id ~timestamp ({ tid; price; amount; maker_side } : T.t)
+          =
+        match Int64.equal event_id tid with
+        | true -> { timestamp; tid; price; amount; maker_side }
+        | false ->
+            failwith
+              "logical error: event_id and trade id (tid) should be equal"
     end
 
     let to_decorated = Decorated.create
@@ -176,283 +187,260 @@ module T = struct
     include T
   end
 
- module Block_trade_event = struct
-   module T = struct
-     type t =
-       {price:Decimal_string.t;
-        amount:Decimal_string.t
-       } [@@deriving of_yojson, sexp, fields, csv]
-   end
-
-   module Decorated = struct
-     type t =
-       {event_id:Int_number.t;
-        timestamp:Timestamp.t;
-        price:Decimal_string.t;
-        amount:Decimal_string.t
-       } [@@deriving of_yojson, sexp, fields, csv]
-
-     let create ~event_id ~timestamp
-           ({price; amount}:T.t) =
-         {event_id;timestamp;price;amount}
+  module Block_trade_event = struct
+    module T = struct
+      type t = { price : Decimal_string.t; amount : Decimal_string.t }
+      [@@deriving of_yojson, sexp, fields, csv]
     end
 
-   let to_decorated = Decorated.create
-   include T
- end
+    module Decorated = struct
+      type t = {
+        event_id : Int_number.t;
+        timestamp : Timestamp.t;
+        price : Decimal_string.t;
+        amount : Decimal_string.t;
+      }
+      [@@deriving of_yojson, sexp, fields, csv]
 
- module Auction_open_event = struct
-  type t =
-    {auction_open_ms:Timestamp.Ms.t;
-     auction_time_ms:Timestamp.Ms.t;
-     first_indicative_ms:Timestamp.Ms.t;
-     last_cancel_time_ms:Timestamp.Ms.t;
-    } [@@deriving sexp, of_yojson, fields, csv]
-end
+      let create ~event_id ~timestamp ({ price; amount } : T.t) =
+        { event_id; timestamp; price; amount }
+    end
 
+    let to_decorated = Decorated.create
+
+    include T
+  end
+
+  module Auction_open_event = struct
+    type t = {
+      auction_open_ms : Timestamp.Ms.t;
+      auction_time_ms : Timestamp.Ms.t;
+      first_indicative_ms : Timestamp.Ms.t;
+      last_cancel_time_ms : Timestamp.Ms.t;
+    }
+    [@@deriving sexp, of_yojson, fields, csv]
+  end
 
   module Auction_result = struct
     module T = struct
-      type t =
-        [`Success | `Failure] [@@deriving sexp, enumerate]
-      let to_string = function
-        | `Success -> "success"
-        | `Failure -> "failure"
+      type t = [ `Success | `Failure ] [@@deriving sexp, enumerate]
+
+      let to_string = function `Success -> "success" | `Failure -> "failure"
     end
+
     include T
-    include (Json.Make(T) : Json.S with type t := t)
+    include (Json.Make (T) : Json.S with type t := t)
   end
 
   module Auction_indicative_price_event = struct
-    type t =
-      {eid:Int_number.t;
-       result:Auction_result.t;
-       time_ms:Timestamp.Ms.t;
-       highest_bid_price:Decimal_string.t;
-       lowest_ask_price:Decimal_string.t;
-       collar_price:Decimal_string.t;
-       indicative_price:Decimal_string.t;
-       indicative_quantity:Decimal_string.t
-      } [@@deriving sexp, of_yojson, fields, csv]
+    type t = {
+      eid : Int_number.t;
+      result : Auction_result.t;
+      time_ms : Timestamp.Ms.t;
+      highest_bid_price : Decimal_string.t;
+      lowest_ask_price : Decimal_string.t;
+      collar_price : Decimal_string.t;
+      indicative_price : Decimal_string.t;
+      indicative_quantity : Decimal_string.t;
+    }
+    [@@deriving sexp, of_yojson, fields, csv]
   end
 
-
   module Auction_outcome_event = struct
-  type t =
-    {eid:Int_number.t;
-     result:Auction_result.t;
-     time_ms:Timestamp.Ms.t;
-     highest_bid_price:Decimal_string.t;
-     lowest_ask_price:Decimal_string.t;
-     collar_price:Decimal_string.t;
-     auction_price:Decimal_string.t;
-     auction_quantity:Decimal_string.t
-    } [@@deriving sexp, of_yojson, fields, csv]
+    type t = {
+      eid : Int_number.t;
+      result : Auction_result.t;
+      time_ms : Timestamp.Ms.t;
+      highest_bid_price : Decimal_string.t;
+      lowest_ask_price : Decimal_string.t;
+      collar_price : Decimal_string.t;
+      auction_price : Decimal_string.t;
+      auction_quantity : Decimal_string.t;
+    }
+    [@@deriving sexp, of_yojson, fields, csv]
   end
 
   module Auction_event_type = struct
     module T = struct
-      type t =
-        [ `Auction_open
-        | `Auction_indicative_price
-        | `Auction_outcome ]
+      type t = [ `Auction_open | `Auction_indicative_price | `Auction_outcome ]
       [@@deriving sexp, enumerate]
 
       let to_string = function
-        | `Auction_open ->
-          "auction_open"
-        | `Auction_indicative_price ->
-          "auction_indicative_price"
-        | `Auction_outcome ->
-          "auction_outcome"
+        | `Auction_open -> "auction_open"
+        | `Auction_indicative_price -> "auction_indicative_price"
+        | `Auction_outcome -> "auction_outcome"
     end
+
     include T
-    include (Json.Make(T) : Json.S with type t := t)
+    include (Json.Make (T) : Json.S with type t := t)
   end
 
   module Auction_event = struct
-  type t =
-    [
-      | `Auction_open of Auction_open_event.t
-      | `Auction_indicative_price of
-          Auction_indicative_price_event.t
-      | `Auction_outcome of Auction_outcome_event.t
-    ] [@@deriving sexp]
+    type t =
+      [ `Auction_open of Auction_open_event.t
+      | `Auction_indicative_price of Auction_indicative_price_event.t
+      | `Auction_outcome of Auction_outcome_event.t ]
+    [@@deriving sexp]
 
-
-  let of_yojson :
-    Yojson.Safe.t -> (t, string) Result.t = function
-    | `Assoc assoc as json ->
-      (List.Assoc.find assoc ~equal:String.equal
-         "type" |> function
-       | None ->
-         Result.failf "no auction event type in json payload: %s"
-           (Yojson.Safe.to_string json)
-       | Some event_type ->
-         Auction_event_type.of_yojson event_type |> function
-         | Result.Error _ as e -> e
-         | Result.Ok event_type ->
-           let json' = `Assoc
-               (List.Assoc.remove ~equal:String.equal assoc "type") in
-           (match event_type with
-            | `Auction_open ->
-              Auction_open_event.of_yojson json' |>
-              Result.map ~f:(fun event -> `Auction_open event)
-            | `Auction_indicative_price ->
-              Auction_indicative_price_event.of_yojson json' |>
-              Result.map ~f:(fun event -> `Auction_indicative_price event)
-            | `Auction_outcome ->
-              Auction_outcome_event.of_yojson json' |>
-              Result.map ~f:(fun event -> `Auction_outcome event)
-           )
-      )
-    | #Yojson.Safe.t as json ->
-      Result.failf "expected association type in json payload: %s"
-        (Yojson.Safe.to_string json)
-end
+    let of_yojson : Yojson.Safe.t -> (t, string) Result.t = function
+      | `Assoc assoc as json -> (
+          List.Assoc.find assoc ~equal:String.equal "type" |> function
+          | None ->
+              Result.failf "no auction event type in json payload: %s"
+                (Yojson.Safe.to_string json)
+          | Some event_type -> (
+              Auction_event_type.of_yojson event_type |> function
+              | Result.Error _ as e -> e
+              | Result.Ok event_type -> (
+                  let json' =
+                    `Assoc (List.Assoc.remove ~equal:String.equal assoc "type")
+                  in
+                  match event_type with
+                  | `Auction_open ->
+                      Auction_open_event.of_yojson json'
+                      |> Result.map ~f:(fun event -> `Auction_open event)
+                  | `Auction_indicative_price ->
+                      Auction_indicative_price_event.of_yojson json'
+                      |> Result.map ~f:(fun event ->
+                             `Auction_indicative_price event)
+                  | `Auction_outcome ->
+                      Auction_outcome_event.of_yojson json'
+                      |> Result.map ~f:(fun event -> `Auction_outcome event))))
+      | #Yojson.Safe.t as json ->
+          Result.failf "expected association type in json payload: %s"
+            (Yojson.Safe.to_string json)
+  end
 
   type event =
     [ `Change of Change_event.t
     | `Trade of Trade_event.t
     | `Auction of Auction_event.t
     | `Auction_open of Auction_open_event.t
-    | `Block_trade of Block_trade_event.t
-    ] [@@deriving sexp]
+    | `Block_trade of Block_trade_event.t ]
+  [@@deriving sexp]
 
-  let event_of_yojson :
-    Yojson.Safe.t -> (event, string) Result.t = function
-    | `Assoc assoc as json ->
-      (List.Assoc.find assoc ~equal:String.equal
-         "type" |> function
-       | None ->
-         Result.failf "no event type in json payload: %s"
-           (Yojson.Safe.to_string json)
-       | Some event_type ->
-         Event_type.of_yojson event_type |> function
-         | Result.Error _ as e -> e
-         | Result.Ok event_type ->
-           let json' = `Assoc
-               (List.Assoc.remove ~equal:String.equal assoc "type") in
-           (match event_type with
-            | `Change ->
-              Change_event.of_yojson json' |>
-              Result.map ~f:(fun event -> `Change event)
-            | `Trade ->
-              Trade_event.of_yojson json' |>
-              Result.map ~f:(fun event -> `Trade event)
-            | `Auction ->
-              Auction_event.of_yojson json' |>
-              Result.map ~f:(fun event -> `Auction event)
-            | `Auction_open ->
-              Auction_open_event.of_yojson json' |>
-              Result.map ~f:(fun event -> `Auction_open event)
-            | `Block_trade ->
-              Block_trade_event.of_yojson json' |>
-              Result.map ~f:(fun event -> `Block_trade event)
-           )
-      )
+  let event_of_yojson : Yojson.Safe.t -> (event, string) Result.t = function
+    | `Assoc assoc as json -> (
+        List.Assoc.find assoc ~equal:String.equal "type" |> function
+        | None ->
+            Result.failf "no event type in json payload: %s"
+              (Yojson.Safe.to_string json)
+        | Some event_type -> (
+            Event_type.of_yojson event_type |> function
+            | Result.Error _ as e -> e
+            | Result.Ok event_type -> (
+                let json' =
+                  `Assoc (List.Assoc.remove ~equal:String.equal assoc "type")
+                in
+                match event_type with
+                | `Change ->
+                    Change_event.of_yojson json'
+                    |> Result.map ~f:(fun event -> `Change event)
+                | `Trade ->
+                    Trade_event.of_yojson json'
+                    |> Result.map ~f:(fun event -> `Trade event)
+                | `Auction ->
+                    Auction_event.of_yojson json'
+                    |> Result.map ~f:(fun event -> `Auction event)
+                | `Auction_open ->
+                    Auction_open_event.of_yojson json'
+                    |> Result.map ~f:(fun event -> `Auction_open event)
+                | `Block_trade ->
+                    Block_trade_event.of_yojson json'
+                    |> Result.map ~f:(fun event -> `Block_trade event))))
     | #Yojson.Safe.t as json ->
-      Result.failf "expected association type in json payload: %s"
-        (Yojson.Safe.to_string json)
-
+        Result.failf "expected association type in json payload: %s"
+          (Yojson.Safe.to_string json)
 
   module Update = struct
-    type t =
-    { event_id : Int_number.t [@key "eventId"];
-      events : event array [@default [||]];
-      timestamp : Timestamp.Sec.t option [@default None];
-      timestampms : Timestamp.Ms.t option [@default None]
-    } [@@deriving sexp, of_yojson]
+    type t = {
+      event_id : Int_number.t; [@key "eventId"]
+      events : event array; [@default [||]]
+      timestamp : Timestamp.Sec.t option; [@default None]
+      timestampms : Timestamp.Ms.t option; [@default None]
+    }
+    [@@deriving sexp, of_yojson]
   end
 
-  type message =
-    [`Heartbeat of heartbeat | `Update of Update.t] [@@deriving sexp]
+  type message = [ `Heartbeat of heartbeat | `Update of Update.t ]
+  [@@deriving sexp]
 
-  type response =
-    {
-      socket_sequence : Int_number.t;
-      message : message
-    } [@@deriving sexp]
+  type response = { socket_sequence : Int_number.t; message : message }
+  [@@deriving sexp]
 
-  let response_of_yojson :
-    Yojson.Safe.t -> (response, string) Result.t = function
-    | `Assoc assoc as json ->
-      (
-        (
-          List.Assoc.find ~equal:String.equal assoc "socket_sequence",
-          List.Assoc.find ~equal:String.equal assoc "type"
-        ) |> function
-        | (None, _) ->
-          Result.failf "no sequence number in json payload: %s"
-            (Yojson.Safe.to_string json)
-        | (_, None) ->
-          Result.failf "no message type in json payload: %s"
-            (Yojson.Safe.to_string json)
-        | (Some socket_sequence, Some message_type) ->
-          Result.both
-            (Int_number.of_yojson socket_sequence)
-            (Message_type.of_yojson message_type) |> function
-          | Result.Error _ as e -> e
-          | Result.Ok (socket_sequence, message_type) ->
-            let json' = `Assoc
-                (List.Assoc.remove
-                   ~equal:String.equal assoc "type" |> fun assoc ->
-                 List.Assoc.remove
-                   ~equal:String.equal assoc "socket_sequence"
-                )
-            in
-            (
-              (match message_type with
-               | `Heartbeat ->
-                 heartbeat_of_yojson json' |>
-                 Result.map ~f:(fun event -> `Heartbeat event)
-               | `Update ->
-                 Update.of_yojson json' |>
-                 Result.map ~f:(fun event -> `Update event)
-              )
-              |> Result.map
-                ~f:(fun message -> {socket_sequence;message})
-            )
-      )
+  let response_of_yojson : Yojson.Safe.t -> (response, string) Result.t =
+    function
+    | `Assoc assoc as json -> (
+        ( List.Assoc.find ~equal:String.equal assoc "socket_sequence",
+          List.Assoc.find ~equal:String.equal assoc "type" )
+        |> function
+        | None, _ ->
+            Result.failf "no sequence number in json payload: %s"
+              (Yojson.Safe.to_string json)
+        | _, None ->
+            Result.failf "no message type in json payload: %s"
+              (Yojson.Safe.to_string json)
+        | Some socket_sequence, Some message_type -> (
+            Result.both
+              (Int_number.of_yojson socket_sequence)
+              (Message_type.of_yojson message_type)
+            |> function
+            | Result.Error _ as e -> e
+            | Result.Ok (socket_sequence, message_type) ->
+                let json' =
+                  `Assoc
+                    ( List.Assoc.remove ~equal:String.equal assoc "type"
+                    |> fun assoc ->
+                      List.Assoc.remove ~equal:String.equal assoc
+                        "socket_sequence" )
+                in
+                (match message_type with
+                | `Heartbeat ->
+                    heartbeat_of_yojson json'
+                    |> Result.map ~f:(fun event -> `Heartbeat event)
+                | `Update ->
+                    Update.of_yojson json'
+                    |> Result.map ~f:(fun event -> `Update event))
+                |> Result.map ~f:(fun message -> { socket_sequence; message })))
     | #Yojson.Safe.t as json ->
-      Result.failf "response_of_yojson:expected association type \
-                    in json payload: %s"
-        (Yojson.Safe.to_string json)
+        Result.failf
+          "response_of_yojson:expected association type in json payload: %s"
+          (Yojson.Safe.to_string json)
 
-  module Csv_of_event = Ws.Csv_of_event(Event_type)
+  module Csv_of_event = Ws.Csv_of_event (Event_type)
 
-  let events_of_response
-    (response:response) =
+  let events_of_response (response : response) =
     let csv_of_events = Csv_of_event.empty in
     match response.message with
     | `Heartbeat _ -> csv_of_events
     | `Update (update : Update.t) ->
-      let event_id = update.event_id in
-      let timestamp =
-        Option.(first_some update.timestamp
-                   update.timestamp |> value ~default:(Time.now())
-               ) in
-      Array.fold ~init:csv_of_events update.events
-        ~f:
-          (fun csv_of_events (event:event) ->
-             (match event with
-              | `Change change ->
+        let event_id = update.event_id in
+        let timestamp =
+          Option.(
+            first_some update.timestamp update.timestamp
+            |> value ~default:(Time.now ()))
+        in
+        Array.fold ~init:csv_of_events update.events
+          ~f:(fun csv_of_events (event : event) ->
+            match event with
+            | `Change change ->
                 Csv_of_event.add' csv_of_events `Change
                   (module Change_event.Decorated)
-                  [Change_event.to_decorated ~event_id ~timestamp change]
-              | `Trade trade ->
+                  [ Change_event.to_decorated ~event_id ~timestamp change ]
+            | `Trade trade ->
                 Csv_of_event.add' csv_of_events `Trade
                   (module Trade_event.Decorated)
-                  [Trade_event.to_decorated ~event_id ~timestamp trade]
-              | `Auction _auction -> csv_of_events
-              | `Auction_open _auction -> csv_of_events
-              | `Block_trade block_trade ->
+                  [ Trade_event.to_decorated ~event_id ~timestamp trade ]
+            | `Auction _auction -> csv_of_events
+            | `Auction_open _auction -> csv_of_events
+            | `Block_trade block_trade ->
                 Csv_of_event.add' csv_of_events `Block_trade
                   (module Block_trade_event.Decorated)
-                  [Block_trade_event.to_decorated
-                     ~event_id ~timestamp block_trade]
-             )
-          )
+                  [
+                    Block_trade_event.to_decorated ~event_id ~timestamp
+                      block_trade;
+                  ])
 end
+
 include T
-include Ws.Make_no_request(T)
+include Ws.Make_no_request (T)

--- a/lib/market_data.ml
+++ b/lib/market_data.ml
@@ -418,7 +418,7 @@ module T = struct
         let timestamp =
           Option.(
             first_some update.timestamp update.timestamp
-            |> value ~default:(Time.now ()))
+            |> value ~default:(Time_float_unix.now ()))
         in
         Array.fold ~init:csv_of_events update.events
           ~f:(fun csv_of_events (event : event) ->

--- a/lib/market_data.mli
+++ b/lib/market_data.mli
@@ -1,125 +1,114 @@
+open! Common
 (** Market data websockets api for the Gemini trading exchange. This
     broadcasts only public events and require no authentication.
 *)
-open! Common
 
 (** Encapsulates various concepts of side in the market dat api. *)
-module Side :
-sig
-
+module Side : sig
   (** Represents a bid or ask side. *)
-  module Bid_ask :
-  sig
+  module Bid_ask : sig
     type t = [ `Ask | `Bid ] [@@deriving sexp]
+
     include Json.S with type t := t
   end
 
   (** Represents an auction style side. *)
-  module Auction :
-  sig
+  module Auction : sig
     type t = [ `Auction ] [@@deriving sexp]
+
     include Json.S with type t := t
   end
 
+  type t = [ Bid_ask.t | Auction.t ] [@@deriving sexp]
   (** A most general type of side- one of [`Bid], [`Ask], or [`Auction]. *)
-  type t = [ Bid_ask.t | Auction.t] [@@deriving sexp]
 
   include Json.S with type t := t
 end
 
 (** Represents market data message types supported by the Gemini exchange. *)
-module Message_type :
-sig
+module Message_type : sig
   (* The support message types for order events -
      either [`Update] or [`Heartbeat].
   *)
-  type t = [`Heartbeat | `Update] [@@deriving sexp]
+  type t = [ `Heartbeat | `Update ] [@@deriving sexp]
+
   include Json.S with type t := t
 end
 
 (** Represents different types of market data events *)
-module Event_type :
-sig
+module Event_type : sig
+  type t = [ `Trade | `Change | `Auction | `Auction_open | `Block_trade ]
+  [@@deriving sexp]
   (** Market data event types. One of  [`Trade], [`Change], [`Auction],
       or [`Block_trade].
   *)
-  type t = [`Trade | `Change | `Auction | `Auction_open | `Block_trade] [@@deriving sexp]
+
   include Json.S with type t := t
   include Comparable with type t := t
 end
 
-(** The heartbeat response type has no payload *)
 type heartbeat = unit [@@deriving sexp, of_yojson]
-
+(** The heartbeat response type has no payload *)
 
 (** Different reasons a market data event occured *)
-module Reason :
-sig
+module Reason : sig
+  type t = [ `Place | `Trade | `Cancel | `Initial ] [@@deriving sexp]
   (** Reasons a market data event occured *)
-  type t =
-    [`Place | `Trade | `Cancel | `Initial]
-  [@@deriving sexp]
+
   include Json.S with type t := t
 end
 
 (** An change event to an order. The [reaosn] field indicates
     the type of change. *)
-module Change_event :
-sig
+module Change_event : sig
   type t = {
     price : Decimal_string.t;
     side : Side.Bid_ask.t;
     reason : Reason.t;
     remaining : Decimal_string.t;
     delta : Decimal_string.t;
-  } [@@deriving sexp, of_yojson, csv, fields]
+  }
+  [@@deriving sexp, of_yojson, csv, fields]
 end
 
 (** An trade event of an order. *)
-module Trade_event :
-sig
+module Trade_event : sig
   type t = {
     tid : Int_number.t;
     price : Decimal_string.t;
     amount : Decimal_string.t;
     maker_side : Side.t;
-  } [@@deriving sexp, of_yojson, fields, csv]
+  }
+  [@@deriving sexp, of_yojson, fields, csv]
 end
 
 (** A block trade event. *)
-module Block_trade_event :
-sig
-  type t = {
-    price : Decimal_string.t;
-    amount : Decimal_string.t;
-  } [@@deriving sexp, of_yojson, fields, csv]
+module Block_trade_event : sig
+  type t = { price : Decimal_string.t; amount : Decimal_string.t }
+  [@@deriving sexp, of_yojson, fields, csv]
 end
 
 (** An auction open event. *)
-module Auction_open_event :
-sig
+module Auction_open_event : sig
   type t = {
     auction_open_ms : Timestamp.Ms.t;
     auction_time_ms : Timestamp.Ms.t;
     first_indicative_ms : Timestamp.Ms.t;
     last_cancel_time_ms : Timestamp.Ms.t;
-  } [@@deriving sexp, of_yojson, fields, csv]
+  }
+  [@@deriving sexp, of_yojson, fields, csv]
 end
 
-
 (** Represents different results possible from an auction. *)
-module Auction_result :
-sig
+module Auction_result : sig
+  type t = [ `Success | `Failure ] [@@deriving sexp]
   (** the type of an auction result- one of [`Success] or [`Failure]. *)
-  type t =
-    [`Success | `Failure] [@@deriving sexp]
+
   include Json.S with type t := t
 end
 
-
 (** An auction indicative price event. *)
-module Auction_indicative_price_event :
-sig
+module Auction_indicative_price_event : sig
   type t = {
     eid : Int_number.t;
     result : Auction_result.t;
@@ -129,12 +118,12 @@ sig
     collar_price : Decimal_string.t;
     indicative_price : Decimal_string.t;
     indicative_quantity : Decimal_string.t;
-  } [@@deriving sexp, of_yojson, fields, csv]
+  }
+  [@@deriving sexp, of_yojson, fields, csv]
 end
 
 (** An auction outcome event. *)
-module Auction_outcome_event :
-sig
+module Auction_outcome_event : sig
   type t = {
     eid : Int_number.t;
     result : Auction_result.t;
@@ -144,72 +133,68 @@ sig
     collar_price : Decimal_string.t;
     auction_price : Decimal_string.t;
     auction_quantity : Decimal_string.t;
-  } [@@deriving sexp, of_yojson, fields, csv]
+  }
+  [@@deriving sexp, of_yojson, fields, csv]
 end
 
 (** Represents different auction event types. *)
-module Auction_event_type :
-sig
-
-  (** Enumerates an auction event type. *)
-  type t =
-    [ `Auction_open | `Auction_indicative_price | `Auction_outcome ]
+module Auction_event_type : sig
+  type t = [ `Auction_open | `Auction_indicative_price | `Auction_outcome ]
   [@@deriving sexp]
+  (** Enumerates an auction event type. *)
+
   include Json.S with type t := t
 end
 
 module Auction_event : sig
-(** The type of an auction event, unified over all auction event types. *)
-type t =
-  [ `Auction_indicative_price of Auction_indicative_price_event.t
-  | `Auction_open of Auction_open_event.t
-  | `Auction_outcome of Auction_outcome_event.t ]
-[@@deriving sexp, of_yojson]
+  type t =
+    [ `Auction_indicative_price of Auction_indicative_price_event.t
+    | `Auction_open of Auction_open_event.t
+    | `Auction_outcome of Auction_outcome_event.t ]
+  [@@deriving sexp, of_yojson]
+  (** The type of an auction event, unified over all auction event types. *)
 end
 
-(** The type of event, unified over auction, change, and trade events. *)
 type event =
   [ `Auction of Auction_event.t
   | `Auction_open of Auction_open_event.t
   | `Change of Change_event.t
   | `Trade of Trade_event.t
-  | `Block_trade of Block_trade_event.t
-  ]
+  | `Block_trade of Block_trade_event.t ]
 [@@deriving sexp, of_yojson]
-
+(** The type of event, unified over auction, change, and trade events. *)
 
 (** The type of a market data update message. *)
 module Update : sig
-  type t  = {
+  type t = {
     event_id : Int_number.t;
     events : event array;
     timestamp : Timestamp.Sec.t option;
     timestampms : Timestamp.Ms.t option;
-  } [@@deriving sexp, of_yojson]
+  }
+  [@@deriving sexp, of_yojson]
 end
 
-(** The type of a market data message- a heartbeat or update. *)
-type message =
-  [ `Heartbeat of heartbeat | `Update of Update.t ]
+type message = [ `Heartbeat of heartbeat | `Update of Update.t ]
 [@@deriving sexp]
+(** The type of a market data message- a heartbeat or update. *)
 
-
+type response = { socket_sequence : Int_number.t; message : message }
+[@@deriving sexp]
 (** The type of a market data response. *)
-type response = {
-  socket_sequence : Int_number.t;
-  message : message;
-} [@@deriving sexp]
 
-include Ws.CHANNEL
-  with module Event_type := Event_type
-  with type uri_args = Symbol.t
-  with type query = unit
-  with type response := response
+include
+  Ws.CHANNEL
+    with module Event_type := Event_type
+    with type uri_args = Symbol.t
+    with type query = unit
+    with type response := response
 
 val client :
   (module Cfg.S) ->
   ?query:Sexp.t list ->
-  ?uri_args:uri_args -> unit ->
+  ?uri_args:uri_args ->
+  unit ->
   response Pipe.Reader.t Deferred.t
 
 val command : string * Command.t

--- a/lib/nonce.ml
+++ b/lib/nonce.ml
@@ -8,86 +8,75 @@ end
 
 module Counter : S with type t = int = struct
   type t = int [@@deriving sexp]
+
   let pipe ~init () =
-    Inf_pipe.unfold ~init
-      ~f:
-        (fun s ->
-           let s' = s + 1 in
-           (s, s') |> return
-        )
+    Inf_pipe.unfold ~init ~f:(fun s ->
+        let s' = s + 1 in
+        (s, s') |> return)
     |> return
 end
 
 module File = struct
-
-  let create_nonce_file ?(default=0) filename =
+  let create_nonce_file ?(default = 0) filename =
     try_with ~extract_exn:true (fun () ->
-        Unix.with_file ~mode:[`Rdonly] filename
-          ~f:(fun _fd ->  Deferred.unit)
-      ) >>= function
+        Unix.with_file ~mode:[ `Rdonly ] filename ~f:(fun _fd -> Deferred.unit))
+    >>= function
     | Result.Ok _ -> Deferred.unit
-    | Result.Error _ ->
-      Writer.save ~contents:(sprintf "%d\n" default) filename
+    | Result.Error _ -> Writer.save ~contents:(sprintf "%d\n" default) filename
 
   type t = string [@@deriving sexp]
-
 
   (* TODO - too expensive- only check the file once, then do
    * everything in memory *)
   let pipe ~init:filename () =
     Cfg.create_config_dir () >>= fun () ->
     create_nonce_file ?default:None filename >>= fun () ->
-    Inf_pipe.unfold ~init:() ~f:
-      (fun _ ->
-         Reader.open_file ?buf_len:None
-           filename >>= Reader.really_read_line
-           ~wait_time:(Time.Span.of_ms 1.0) >>=
-         (function
-           | None -> return 0
-           | Some nonce -> return @@ Int.of_string nonce
-         ) >>= fun nonce ->
-         let nonce' = nonce + 1 in
-         Writer.save filename
-           ~contents:(sprintf "%d\n" nonce') >>= fun () ->
-         return (nonce, ())
-      ) |> return
+    Inf_pipe.unfold ~init:() ~f:(fun _ ->
+        (Reader.open_file ?buf_len:None filename
+         >>= Reader.really_read_line ~wait_time:(Time.Span.of_ms 1.0)
+         >>= function
+         | None -> return 0
+         | Some nonce -> return @@ Int.of_string nonce)
+        >>= fun nonce ->
+        let nonce' = nonce + 1 in
+        Writer.save filename ~contents:(sprintf "%d\n" nonce') >>= fun () ->
+        return (nonce, ()))
+    |> return
 
   let default_filename =
     let root_path = Unix.getenv_exn "HOME" in
     sprintf "%s/.gemini/nonce.txt" root_path
-
 end
 
 let _assert_module_file_is_nonce =
-  let module F = (File : S with type t = string) in ()
+  let module F : S with type t = string = File in
+  ()
 
 module Request = struct
+  type request_nonce = { request : string; nonce : int }
+  [@@deriving sexp, yojson]
 
-  type request_nonce =
-    {request:string; nonce:int} [@@deriving sexp, yojson]
-
-  type t =
-    {request:string; nonce:int; payload:Yojson.Safe.t option [@default None]}
+  type t = {
+    request : string;
+    nonce : int;
+    payload : Yojson.Safe.t option; [@default None]
+  }
 
   let make ~request ~nonce ?payload () =
-    Inf_pipe.read nonce >>= fun nonce ->
-      return
-        {request;nonce;payload}
+    Inf_pipe.read nonce >>= fun nonce -> return { request; nonce; payload }
 
-  let to_yojson {request;nonce;payload} : Yojson.Safe.t =
-    match request_nonce_to_yojson {request;nonce} with
-    | `Assoc assoc as a ->
-      (match Option.value ~default:`Null payload with
-       | `Null -> a
-       | `Assoc assoc' ->
-         `Assoc (assoc @ assoc')
-       | #Yojson.Safe.t as unsupported_yojson ->
-         failwithf "expected json association for request payload but got %S"
-           (Yojson.Safe.to_string unsupported_yojson) ()
-      )
+  let to_yojson { request; nonce; payload } : Yojson.Safe.t =
+    match request_nonce_to_yojson { request; nonce } with
+    | `Assoc assoc as a -> (
+        match Option.value ~default:`Null payload with
+        | `Null -> a
+        | `Assoc assoc' -> `Assoc (assoc @ assoc')
+        | #Yojson.Safe.t as unsupported_yojson ->
+            failwithf "expected json association for request payload but got %S"
+              (Yojson.Safe.to_string unsupported_yojson)
+              ())
     | #Yojson.Safe.t as unsupported_yojson ->
-      failwithf "expected json association for type request_nonce but got %S"
-        (Yojson.Safe.to_string unsupported_yojson) ()
-
+        failwithf "expected json association for type request_nonce but got %S"
+          (Yojson.Safe.to_string unsupported_yojson)
+          ()
 end
-

--- a/lib/nonce.ml
+++ b/lib/nonce.ml
@@ -33,7 +33,7 @@ module File = struct
     create_nonce_file ?default:None filename >>= fun () ->
     Inf_pipe.unfold ~init:() ~f:(fun _ ->
         (Reader.open_file ?buf_len:None filename
-         >>= Reader.really_read_line ~wait_time:(Time.Span.of_ms 1.0)
+         >>= Reader.really_read_line ~wait_time:(Time_float_unix.Span.of_ms 1.0)
          >>= function
          | None -> return 0
          | Some nonce -> return @@ Int.of_string nonce)

--- a/lib/order_events.ml
+++ b/lib/order_events.ml
@@ -4,33 +4,37 @@ module Request = Nonce.Request
 module T = struct
   let name = "orderevents"
   let version = v1
-  let path = version::["order";"events"]
-  type uri_args = [`None] [@@deriving sexp, enumerate]
+  let path = version :: [ "order"; "events" ]
+
+  type uri_args = [ `None ] [@@deriving sexp, enumerate]
 
   let authentication = `Private
-
   let default_uri_args = None
+
   let encode_uri_args _ =
     failwith "uri path arguments not support for order events"
-  type heartbeat = {timestampms:Timestamp.Ms.t;
-                    sequence:Int_number.t;
-                    trace_id:string;
-                    socket_sequence:Int_number.t
-                   } [@@deriving sexp, yojson]
 
- module Order_event_type = struct
+  type heartbeat = {
+    timestampms : Timestamp.Ms.t;
+    sequence : Int_number.t;
+    trace_id : string;
+    socket_sequence : Int_number.t;
+  }
+  [@@deriving sexp, yojson]
+
+  module Order_event_type = struct
     module T = struct
-
-      type t = [ `Subscription_ack
-               | `Heartbeat
-               | `Initial
-               | `Accepted
-               | `Rejected
-               | `Booked
-               | `Fill
-               | `Cancelled
-               | `Closed
-               ] [@@deriving sexp, enumerate, compare]
+      type t =
+        [ `Subscription_ack
+        | `Heartbeat
+        | `Initial
+        | `Accepted
+        | `Rejected
+        | `Booked
+        | `Fill
+        | `Cancelled
+        | `Closed ]
+      [@@deriving sexp, enumerate, compare]
 
       let to_string : t -> string = function
         | `Subscription_ack -> "subscription_ack"
@@ -43,91 +47,91 @@ module T = struct
         | `Cancelled -> "cancelled"
         | `Closed -> "closed"
     end
+
     include T
-    include Comparable.Make(T)
-    include (Json.Make(T) : Json.S with type t := t)
+    include Comparable.Make (T)
+    include (Json.Make (T) : Json.S with type t := t)
   end
 
-
- type query =
-   [ `Symbol_filter of Symbol.t
-   | `Event_type_filter of Order_event_type.t
-   | `Api_session_filter of string
-   ] [@@deriving sexp]
+  type query =
+    [ `Symbol_filter of Symbol.t
+    | `Event_type_filter of Order_event_type.t
+    | `Api_session_filter of string ]
+  [@@deriving sexp]
 
   let encode_query = function
-      | `Symbol_filter symbol ->
-        "symbolFilter", Symbol.to_string symbol
-      | `Event_type_filter event_type ->
-        "eventTypeFilter", Order_event_type.to_string event_type
-      | `Api_session_filter session ->
-        "apiSessionFilter", session
+    | `Symbol_filter symbol -> ("symbolFilter", Symbol.to_string symbol)
+    | `Event_type_filter event_type ->
+        ("eventTypeFilter", Order_event_type.to_string event_type)
+    | `Api_session_filter session -> ("apiSessionFilter", session)
 
-   module Reason = struct
+  module Reason = struct
     module T = struct
-      type t =
-        [`Place | `Trade | `Cancel | `Initial] [@@deriving sexp, enumerate]
+      type t = [ `Place | `Trade | `Cancel | `Initial ]
+      [@@deriving sexp, enumerate]
+
       let to_string = function
         | `Place -> "place"
         | `Trade -> "trade"
         | `Cancel -> "cancel"
         | `Initial -> "initial"
     end
+
     include T
-    include (Json.Make(T) : Json.S with type t := t)
+    include (Json.Make (T) : Json.S with type t := t)
   end
 
-   module Reject_reason = struct
+  module Reject_reason = struct
     module T = struct
-      type t =
-        [`Invalid_quantity] [@@deriving sexp, enumerate]
-      let to_string = function
-        | `Invalid_quantity -> "InvalidQuantity"
+      type t = [ `Invalid_quantity ] [@@deriving sexp, enumerate]
+
+      let to_string = function `Invalid_quantity -> "InvalidQuantity"
     end
+
     include T
-    include (Json.Make(T) : Json.S with type t := t)
+    include (Json.Make (T) : Json.S with type t := t)
   end
 
   module Liquidity = struct
-  module T = struct
-  type t = [`Taker] [@@deriving sexp, enumerate]
-  (* TODO determine other liquidities *)
-  let to_string = function
-    | `Taker -> "Taker"
-end
-  include T
-  include (Json.Make(T) : Json.S with type t := t)
+    module T = struct
+      type t = [ `Taker ] [@@deriving sexp, enumerate]
+
+      (* TODO determine other liquidities *)
+      let to_string = function `Taker -> "Taker"
+    end
+
+    include T
+    include (Json.Make (T) : Json.S with type t := t)
   end
 
   module Fill = struct
     type t = {
-      trade_id:Int_string.t;
-      liquidity:Liquidity.t;
-      price:Decimal_string.t;
-      amount:Decimal_string.t;
-      fee:Decimal_string.t;
-      fee_currency:Currency.t;
-    } [@@deriving sexp, yojson, fields, csv]
+      trade_id : Int_string.t;
+      liquidity : Liquidity.t;
+      price : Decimal_string.t;
+      amount : Decimal_string.t;
+      fee : Decimal_string.t;
+      fee_currency : Currency.t;
+    }
+    [@@deriving sexp, yojson, fields, csv]
   end
 
   module Api_session = struct
     (* TODO make an enum from UI, and whatever the other values are *)
     type t = string [@@deriving sexp, yojson]
-    include
-      (Csvfields.Csv.Atom(String) : Csvfields.Csv.Csvable with type t := t)
+
+    include (
+      Csvfields.Csv.Atom (String) : Csvfields.Csv.Csvable with type t := t)
   end
 
   module Decimal_string_option =
-    Csv_support.Optional.Make
-      (Csv_support.Optional.Default_args(Decimal_string))
+    Csv_support.Optional.Make (Csv_support.Optional.Default_args (Decimal_string))
 
-
-  module Fill_option =
-  struct
-    module T =
-    struct
+  module Fill_option = struct
+    module T = struct
       type t = Fill.t option [@@deriving yojson, sexp]
-      let of_string  = function
+
+      let of_string = function
         | "" -> None
         | s -> String.split ~on:' ' s |> Fill.t_of_row |> Option.some
 
@@ -135,106 +139,103 @@ end
         | None -> ""
         | Some fill -> Fill.row_of_t fill |> String.concat ~sep:" "
     end
+
     include T
-    include (Csvfields.Csv.Atom(T) :  Csvfields.Csv.Csvable with type t := t)
+    include (Csvfields.Csv.Atom (T) : Csvfields.Csv.Csvable with type t := t)
   end
 
-  module Reject_reason_option =
-    Csv_support.Optional.Make_default(Reject_reason)
+  module Reject_reason_option = Csv_support.Optional.Make_default (Reject_reason)
 
   module Order_event = struct
     open Csv_support
-  type t =
-    {order_id:string;
-     api_session:Api_session.t;
-     client_order_id:Optional.String.t [@default None];
-     event_id:Optional.String.t [@default None];
-     order_type:Order_type.t;
-     symbol:Symbol.t;
-     reason:Reject_reason_option.t [@default None];
-     side:Side.t;
-     behavior:Optional.String.t [@default None] (* TODO make enum *);
-     type_ : Order_event_type.t [@key "type"];
-     timestamp:Timestamp.t;
-     timestampms:Timestamp.Ms.t;
-     is_live : bool;
-     is_cancelled : bool;
-     is_hidden : bool;
-     avg_execution_price : Decimal_string_option.t [@default None];
-     executed_amount : Decimal_string_option.t [@default None];
-     remaining_amount : Decimal_string_option.t [@default None];
-     original_amount : Decimal_string_option.t [@default None];
-     price : Decimal_string_option.t [@default None];
-     total_spend : Decimal_string_option.t [@default None];
-     fill : Fill_option.t [@default None];
-     socket_sequence:Int_number.t
-    } [@@deriving sexp, yojson, fields, csv]
-end
 
-module Event_type_list = Csv_support.List.Make_default(Order_event_type)
-module Symbol_list = Csv_support.List.Make_default(Symbol)
+    type t = {
+      order_id : string;
+      api_session : Api_session.t;
+      client_order_id : Optional.String.t; [@default None]
+      event_id : Optional.String.t; [@default None]
+      order_type : Order_type.t;
+      symbol : Symbol.t;
+      reason : Reject_reason_option.t; [@default None]
+      side : Side.t;
+      behavior : Optional.String.t; [@default None] (* TODO make enum *)
+      type_ : Order_event_type.t; [@key "type"]
+      timestamp : Timestamp.t;
+      timestampms : Timestamp.Ms.t;
+      is_live : bool;
+      is_cancelled : bool;
+      is_hidden : bool;
+      avg_execution_price : Decimal_string_option.t; [@default None]
+      executed_amount : Decimal_string_option.t; [@default None]
+      remaining_amount : Decimal_string_option.t; [@default None]
+      original_amount : Decimal_string_option.t; [@default None]
+      price : Decimal_string_option.t; [@default None]
+      total_spend : Decimal_string_option.t; [@default None]
+      fill : Fill_option.t; [@default None]
+      socket_sequence : Int_number.t;
+    }
+    [@@deriving sexp, yojson, fields, csv]
+  end
 
-module Subscription_ack = struct
-type t =
-  {account_id:Int_number.t [@key "accountId"];
-   subscription_id:string [@key "subscriptionId"];
-   symbol_filter:Symbol_list.t [@key "symbolFilter"];
-   api_session_fiter:Csv_support.List.String.t [@key "apiSessionFilter"];
-   event_type_filter:Event_type_list.t [@key "eventTypeFilter"]
-  } [@@deriving sexp, yojson, fields, csv]
-end
+  module Event_type_list = Csv_support.List.Make_default (Order_event_type)
+  module Symbol_list = Csv_support.List.Make_default (Symbol)
 
-type response =
-  [ `Subscription_ack of Subscription_ack.t
-  | `Heartbeat of heartbeat
-  | `Order_event of Order_event.t
-  | `Order_events of Order_event.t list
-  ] [@@deriving sexp]
+  module Subscription_ack = struct
+    type t = {
+      account_id : Int_number.t; [@key "accountId"]
+      subscription_id : string; [@key "subscriptionId"]
+      symbol_filter : Symbol_list.t; [@key "symbolFilter"]
+      api_session_fiter : Csv_support.List.String.t; [@key "apiSessionFilter"]
+      event_type_filter : Event_type_list.t; [@key "eventTypeFilter"]
+    }
+    [@@deriving sexp, yojson, fields, csv]
+  end
 
-let response_of_yojson :
-    Yojson.Safe.t -> ('a, string) Result.t = function
-    | `Assoc assoc as json ->
-      (List.Assoc.find assoc ~equal:String.equal
-         "type" |> function
-       | None ->
-         Log.Global.debug "no type in event payload: %s"
-           (Yojson.Safe.to_string json);
-         Subscription_ack.of_yojson json |>
-         Result.map ~f:(fun event -> `Subscription_ack event);
-       | Some event_type ->
-         Log.Global.debug "found type in event payload: %s"
-           (Yojson.Safe.to_string json);
-          Order_event_type.of_yojson event_type |> function
-         | Result.Error _ as e -> e
-         | Result.Ok event_type ->
-           let json' = `Assoc
-               (List.Assoc.remove ~equal:String.equal assoc "type") in
-           (match event_type with
-            | `Heartbeat ->
-              heartbeat_of_yojson json' |>
-              Result.map ~f:(fun event -> `Heartbeat event)
-            | `Subscription_ack ->
-              Subscription_ack.of_yojson json' |>
-              Result.map ~f:(fun event -> `Subscription_ack event)
-            | #Order_event_type.t ->
-              Order_event.of_yojson json |>
-              Result.map ~f:(fun event -> `Order_event event)
-           )
-      )
+  type response =
+    [ `Subscription_ack of Subscription_ack.t
+    | `Heartbeat of heartbeat
+    | `Order_event of Order_event.t
+    | `Order_events of Order_event.t list ]
+  [@@deriving sexp]
 
+  let response_of_yojson : Yojson.Safe.t -> ('a, string) Result.t = function
+    | `Assoc assoc as json -> (
+        List.Assoc.find assoc ~equal:String.equal "type" |> function
+        | None ->
+            Log.Global.debug "no type in event payload: %s"
+              (Yojson.Safe.to_string json);
+            Subscription_ack.of_yojson json
+            |> Result.map ~f:(fun event -> `Subscription_ack event)
+        | Some event_type -> (
+            Log.Global.debug "found type in event payload: %s"
+              (Yojson.Safe.to_string json);
+            Order_event_type.of_yojson event_type |> function
+            | Result.Error _ as e -> e
+            | Result.Ok event_type -> (
+                let json' =
+                  `Assoc (List.Assoc.remove ~equal:String.equal assoc "type")
+                in
+                match event_type with
+                | `Heartbeat ->
+                    heartbeat_of_yojson json'
+                    |> Result.map ~f:(fun event -> `Heartbeat event)
+                | `Subscription_ack ->
+                    Subscription_ack.of_yojson json'
+                    |> Result.map ~f:(fun event -> `Subscription_ack event)
+                | #Order_event_type.t ->
+                    Order_event.of_yojson json
+                    |> Result.map ~f:(fun event -> `Order_event event))))
     | (`List l : Yojson.Safe.t) ->
-      Result.(all (List.map l ~f:Order_event.of_yojson) |>
-              map ~f:(fun x -> `Order_events x)
-             )
+        Result.(
+          all (List.map l ~f:Order_event.of_yojson)
+          |> map ~f:(fun x -> `Order_events x))
     | #Yojson.Safe.t as json ->
-      Result.failf "expected association type in json payload: %s"
-        (Yojson.Safe.to_string json)
-
+        Result.failf "expected association type in json payload: %s"
+          (Yojson.Safe.to_string json)
 
   module Event_type = struct
-    module T =
-    struct
-      type t = [`Order_event | `Subscription_ack]
+    module T = struct
+      type t = [ `Order_event | `Subscription_ack ]
       [@@deriving sexp, yojson, enumerate, compare]
 
       let to_string = function
@@ -243,27 +244,29 @@ let response_of_yojson :
     end
 
     include T
-    include Comparable.Make(T)
-    include (Json.Make(T) : Json.S with type t := t)
+    include Comparable.Make (T)
+    include (Json.Make (T) : Json.S with type t := t)
   end
 
-  module Csv_of_event = Ws.Csv_of_event(Event_type)
-  let events_of_response (response:response) =
+  module Csv_of_event = Ws.Csv_of_event (Event_type)
+
+  let events_of_response (response : response) =
     let csv_of_event = Csv_of_event.empty in
     match response with
     | `Order_event order_event ->
-      Csv_of_event.add' csv_of_event `Order_event
-        (module Order_event) [order_event]
+        Csv_of_event.add' csv_of_event `Order_event
+          (module Order_event)
+          [ order_event ]
     | `Heartbeat _ -> csv_of_event
     | `Order_events order_events ->
-      Csv_of_event.add' csv_of_event `Order_event
-        (module Order_event) order_events
+        Csv_of_event.add' csv_of_event `Order_event
+          (module Order_event)
+          order_events
     | `Subscription_ack ack ->
-      Csv_of_event.add' csv_of_event `Subscription_ack
-        (module Subscription_ack) [ack]
-
+        Csv_of_event.add' csv_of_event `Subscription_ack
+          (module Subscription_ack)
+          [ ack ]
 end
 
 include T
-include Ws.Make(T)
-
+include Ws.Make (T)

--- a/lib/order_events.mli
+++ b/lib/order_events.mli
@@ -5,156 +5,155 @@
 *)
 
 open Common
-
 module Request = Nonce.Request
 
-
+type uri_args = [ `None ] [@@deriving sexp, enumerate]
 (** The order events api has no uri arguments .*)
-type uri_args = [`None] [@@deriving sexp, enumerate]
 
+type heartbeat = {
+  timestampms : Timestamp.Ms.t;
+  sequence : Int_number.t;
+  trace_id : string;
+  socket_sequence : Int_number.t;
+}
+[@@deriving sexp, yojson]
 (** Response type for heart beat messages. *)
-type heartbeat = {timestampms:Timestamp.Ms.t;
-                  sequence:Int_number.t;
-                  trace_id:string;
-                  socket_sequence:Int_number.t
-                 } [@@deriving sexp, yojson]
-
 
 (** Represents different order event types. *)
 module Order_event_type : sig
-
+  type t =
+    [ `Subscription_ack
+    | `Heartbeat
+    | `Initial
+    | `Accepted
+    | `Rejected
+    | `Booked
+    | `Fill
+    | `Cancelled
+    | `Closed ]
+  [@@deriving sexp, enumerate, compare]
   (** Enumerates all possible order events. *)
-  type t = [ `Subscription_ack
-           | `Heartbeat
-           | `Initial
-           | `Accepted
-           | `Rejected
-           | `Booked
-           | `Fill
-           | `Cancelled
-           | `Closed
-           ] [@@deriving sexp, enumerate, compare]
 
   include Json.S with type t := t
   include Comparable with type t := t
-
 end
 
+type query =
+  [ `Symbol_filter of Symbol.t
+  | `Event_type_filter of Order_event_type.t
+  | `Api_session_filter of string ]
+[@@deriving sexp]
 (** Events can be filtered by symbol using [Symbol_filter symbol] or
     for an event type using [Order_event_type_filter event_type] or using
     an api session filter [Api_session_filter session-id].
 *)
-type query = [ `Symbol_filter of Symbol.t
-             | `Event_type_filter of Order_event_type.t
-             | `Api_session_filter of string
-             ] [@@deriving sexp]
 
 (** Represents differents reasons an order event occurred. *)
 module Reason : sig
-  type t =
-    [`Place | `Trade | `Cancel | `Initial] [@@deriving sexp, enumerate]
+  type t = [ `Place | `Trade | `Cancel | `Initial ] [@@deriving sexp, enumerate]
+
   include Json.ENUM_STRING with type t := t
 end
 
+module Reject_reason : sig
+  type t = [ `Invalid_quantity ] [@@deriving sexp, enumerate]
 
-module Reject_reason :
-sig
-  type t = [`Invalid_quantity] [@@deriving sexp, enumerate]
   include Json.ENUM_STRING with type t := t
 end
 
 (** Represents different liquidity types *)
 module Liquidity : sig
-
+  type t = [ `Taker ] [@@deriving sexp, enumerate]
   (** [Taker] is the only known liquidity type but this
       is poorly documented so other values might exist.
   *)
-  type t = [`Taker] [@@deriving sexp, enumerate]
+
   include Json.ENUM_STRING with type t := t
 end
 
 (** Type type of an order fill event. *)
-module Fill :
-sig
+module Fill : sig
   type t = {
-    trade_id:Int_string.t;
-    liquidity:Liquidity.t;
-    price:Decimal_string.t;
-    amount:Decimal_string.t;
-    fee:Decimal_string.t;
-    fee_currency:Currency.t;
-  } [@@deriving sexp, yojson, fields, csv]
+    trade_id : Int_string.t;
+    liquidity : Liquidity.t;
+    price : Decimal_string.t;
+    amount : Decimal_string.t;
+    fee : Decimal_string.t;
+    fee_currency : Currency.t;
+  }
+  [@@deriving sexp, yojson, fields, csv]
 end
 
 (** Represents an api session name *)
 module Api_session : sig
-
-  (** An api session name. *)
   type t = string [@@deriving sexp, yojson]
+  (** An api session name. *)
 end
 
-
 module Order_event : sig
-(** The type of an order event. *)
-type t =
-  {order_id:string;
-   api_session:Api_session.t;
-   client_order_id:string option [@default None];
-   event_id:string option [@default None];
-   order_type:Order_type.t;
-   symbol:Symbol.t;
-   reason:Reject_reason.t option [@default None];
-   side:Side.t;
-   behavior:string option [@default None];
-   type_ : Order_event_type.t [@key "type"];
-   timestamp:Timestamp.t;
-   timestampms:Timestamp.Ms.t;
-   is_live : bool;
-   is_cancelled : bool;
-   is_hidden : bool;
-   avg_execution_price : Decimal_string.t option [@default None];
-   executed_amount : Decimal_string.t option [@default None];
-   remaining_amount : Decimal_string.t option [@default None];
-   original_amount : Decimal_string.t option [@default None];
-   price : Decimal_string.t option [@default None];
-   total_spend : Decimal_string.t option [@default None];
-   fill : Fill.t option [@default None];
-   socket_sequence:Int_number.t
-  } [@@deriving sexp, yojson, fields, csv]
+  type t = {
+    order_id : string;
+    api_session : Api_session.t;
+    client_order_id : string option; [@default None]
+    event_id : string option; [@default None]
+    order_type : Order_type.t;
+    symbol : Symbol.t;
+    reason : Reject_reason.t option; [@default None]
+    side : Side.t;
+    behavior : string option; [@default None]
+    type_ : Order_event_type.t; [@key "type"]
+    timestamp : Timestamp.t;
+    timestampms : Timestamp.Ms.t;
+    is_live : bool;
+    is_cancelled : bool;
+    is_hidden : bool;
+    avg_execution_price : Decimal_string.t option; [@default None]
+    executed_amount : Decimal_string.t option; [@default None]
+    remaining_amount : Decimal_string.t option; [@default None]
+    original_amount : Decimal_string.t option; [@default None]
+    price : Decimal_string.t option; [@default None]
+    total_spend : Decimal_string.t option; [@default None]
+    fill : Fill.t option; [@default None]
+    socket_sequence : Int_number.t;
+  }
+  [@@deriving sexp, yojson, fields, csv]
+  (** The type of an order event. *)
 end
 
 module Subscription_ack : sig
-(** The type of a subscription acknowledgement event. *)
-type t =
-  {account_id:Int_number.t [@key "accountId"];
-   subscription_id:string [@key "subscriptionId"];
-   symbol_filter:Symbol.t list [@key "symbolFilter"];
-   api_session_fiter:string list [@key "apiSessionFilter"];
-   event_type_filter:Order_event_type.t list [@key "eventTypeFilter"]
-  } [@@deriving sexp, yojson, fields, csv]
+  type t = {
+    account_id : Int_number.t; [@key "accountId"]
+    subscription_id : string; [@key "subscriptionId"]
+    symbol_filter : Symbol.t list; [@key "symbolFilter"]
+    api_session_fiter : string list; [@key "apiSessionFilter"]
+    event_type_filter : Order_event_type.t list; [@key "eventTypeFilter"]
+  }
+  [@@deriving sexp, yojson, fields, csv]
+  (** The type of a subscription acknowledgement event. *)
 end
 
-(** The response type for any order message. *)
 type response =
   [ `Subscription_ack of Subscription_ack.t
   | `Heartbeat of heartbeat
   | `Order_event of Order_event.t
-  | `Order_events of Order_event.t list
-  ] [@@deriving sexp]
+  | `Order_events of Order_event.t list ]
+[@@deriving sexp]
+(** The response type for any order message. *)
 
 module Event_type : sig
-  type t = [`Order_event | `Subscription_ack]
+  type t = [ `Order_event | `Subscription_ack ]
   [@@deriving sexp, enumerate, compare]
+
   include Comparable.S with type t := t
   include Json.S with type t := t
 end
 
-
-include Ws.CHANNEL
-  with module Event_type := Event_type
-  with type uri_args := uri_args
-  with type query := query
-  with type response := response
+include
+  Ws.CHANNEL
+    with module Event_type := Event_type
+    with type uri_args := uri_args
+    with type query := query
+    with type response := response
 
 val command : string * Async.Command.t
 
@@ -163,5 +162,5 @@ val client :
   (module Cfg.S) ->
   ?query:Sexp.t list ->
   ?uri_args:uri_args ->
-  unit -> response Pipe.Reader.t Deferred.t
-
+  unit ->
+  response Pipe.Reader.t Deferred.t

--- a/lib/path.ml
+++ b/lib/path.ml
@@ -1,22 +1,14 @@
 (** Path utilities for encoding them into uris or human readable formats. *)
 
-(** The type of a uri path *)
 type t = string list
+(** The type of a uri path *)
 
 (** Produces the string representation of a path
    suitable for a uri encoding. *)
-let to_string (path:t) = sprintf "/%s"
-    (String.concat ~sep:"/" path)
+let to_string (path : t) = sprintf "/%s" (String.concat ~sep:"/" path)
 
 (** Summarize the path in a human readable format. *)
-let to_summary ~has_subnames (path:t) =
+let to_summary ~has_subnames (path : t) =
   sprintf "Gemini %s Command%s"
     (String.concat ~sep:" " path)
-    (match has_subnames with
-     | true -> "s"
-     | false -> ""
-    )
-
-
-
-
+    (match has_subnames with true -> "s" | false -> "")

--- a/lib/rest.ml
+++ b/lib/rest.ml
@@ -1,24 +1,24 @@
 module Error = struct
-  type http = [ `Bad_request of string
-              | `Not_found
-              | `Service_unavailable of string
-              | `Not_acceptable of string
-              | `Unauthorized of string] [@@deriving sexp]
-  type json_error = {message:string;body:string} [@@deriving sexp]
-  type json = [`Json_parse_error of json_error] [@@deriving sexp]
+  type http =
+    [ `Bad_request of string
+    | `Not_found
+    | `Service_unavailable of string
+    | `Not_acceptable of string
+    | `Unauthorized of string ]
+  [@@deriving sexp]
 
-  type detail = {reason:string;message:string} [@@deriving sexp, yojson]
-  type response = [`Error of detail] [@@deriving sexp]
-
-  type post = [http|json|response] [@@deriving sexp]
+  type json_error = { message : string; body : string } [@@deriving sexp]
+  type json = [ `Json_parse_error of json_error ] [@@deriving sexp]
+  type detail = { reason : string; message : string } [@@deriving sexp, yojson]
+  type response = [ `Error of detail ] [@@deriving sexp]
+  type post = [ http | json | response ] [@@deriving sexp]
 end
 
-
 module Operation = struct
-
   module type S = sig
     val name : string
     val path : string list
+
     type request [@@deriving sexp, to_yojson]
     type response [@@deriving sexp, of_yojson]
   end
@@ -26,219 +26,154 @@ module Operation = struct
   module type S_NO_ARG = sig
     include S with type request = unit
   end
-
 end
 
 module Request = Nonce.Request
 
 module Response = struct
-
   module Json_result = struct
     module T = struct
-    type t = [`Error | `Ok] [@@deriving sexp, enumerate]
-    let to_string = function
-      | `Error -> "error"
-      | `Ok -> "ok"
+      type t = [ `Error | `Ok ] [@@deriving sexp, enumerate]
+
+      let to_string = function `Error -> "error" | `Ok -> "ok"
     end
+
     include T
-    include (Json.Make(T) : Json.S with type t := t)
+    include (Json.Make (T) : Json.S with type t := t)
 
     let split = function
-      | `Assoc assoc as json ->
-      (List.Assoc.find assoc ~equal:String.equal
-        "result" |> function
-       | None -> Result.Ok (None, json)
-       | Some json' ->
-        of_yojson json' |> Result.map ~f:(fun x ->
-          (Some x,
-           `Assoc
-             (List.Assoc.remove
-                assoc ~equal:String.equal "result"
-             )
-          )
-        )
-      )
-      | #Yojson.Safe.t as json ->
-        Result.Ok (None, json)
-
+      | `Assoc assoc as json -> (
+          List.Assoc.find assoc ~equal:String.equal "result" |> function
+          | None -> Result.Ok (None, json)
+          | Some json' ->
+              of_yojson json'
+              |> Result.map ~f:(fun x ->
+                     ( Some x,
+                       `Assoc
+                         (List.Assoc.remove assoc ~equal:String.equal "result")
+                     )))
+      | #Yojson.Safe.t as json -> Result.Ok (None, json)
   end
 
-  type result_field =
-    {result:Json_result.t} [@@deriving of_yojson, sexp]
-
-  type t = {result:Json_result.t; payload:Yojson.Safe.t}
-
+  type result_field = { result : Json_result.t } [@@deriving of_yojson, sexp]
+  type t = { result : Json_result.t; payload : Yojson.Safe.t }
 
   let parse json ok_of_yojson =
     match Json_result.split json with
-    | Result.Ok (result, payload) ->
-      (match result with
-      | None
-      | Some `Ok ->
-        (ok_of_yojson payload |> function
-          | Result.Ok x -> `Ok x
-          | Result.Error e ->
-            `Json_parse_error
-              Error.{message=e; body=Yojson.Safe.to_string payload}
-
-        )
-      | Some `Error ->
-        (Error.detail_of_yojson payload |> function
-          | Result.Ok x -> `Error x
-          | Result.Error e ->
-            `Json_parse_error
-              Error.{message=e; body=Yojson.Safe.to_string payload}
-        )
-      )
+    | Result.Ok (result, payload) -> (
+        match result with
+        | None | Some `Ok -> (
+            ok_of_yojson payload |> function
+            | Result.Ok x -> `Ok x
+            | Result.Error e ->
+                `Json_parse_error
+                  Error.{ message = e; body = Yojson.Safe.to_string payload })
+        | Some `Error -> (
+            Error.detail_of_yojson payload |> function
+            | Result.Ok x -> `Error x
+            | Result.Error e ->
+                `Json_parse_error
+                  Error.{ message = e; body = Yojson.Safe.to_string payload }))
     | Result.Error e ->
-      `Json_parse_error
-        Error.{message=e;body=Yojson.Safe.to_string json}
-
+        `Json_parse_error
+          Error.{ message = e; body = Yojson.Safe.to_string json }
 end
 
-module Post(Operation:Operation.S) :
-  sig
-    val post :
-      (module Cfg.S) ->
-      Nonce.reader ->
-      Operation.request ->
-      [
-      | `Ok of Operation.response
-      | Error.post
-      ] Deferred.t
-  end =
-struct
-  let post
-      (module Cfg : Cfg.S)
-      (nonce : Nonce.reader)
+module Post (Operation : Operation.S) : sig
+  val post :
+    (module Cfg.S) ->
+    Nonce.reader ->
+    Operation.request ->
+    [ `Ok of Operation.response | Error.post ] Deferred.t
+end = struct
+  let post (module Cfg : Cfg.S) (nonce : Nonce.reader)
       (request : Operation.request) :
-    [ `Ok of Operation.response
-    | Error.post] Deferred.t =
-    let payload =
-      Operation.request_to_yojson request in
+      [ `Ok of Operation.response | Error.post ] Deferred.t =
+    let payload = Operation.request_to_yojson request in
     let path = Path.to_string Operation.path in
-     Request.make ~nonce
-      ~request:path ~payload () >>=
-    fun request ->
-    (Request.to_yojson request |>
-     Yojson.Safe.pretty_to_string |>
-     fun s ->
-     Log.Global.debug "request as json:\n %s" s;
-     return @@ Auth.of_payload s
-    )
+    Request.make ~nonce ~request:path ~payload () >>= fun request ->
+    ( Request.to_yojson request |> Yojson.Safe.pretty_to_string |> fun s ->
+      Log.Global.debug "request as json:\n %s" s;
+      return @@ Auth.of_payload s )
     >>= fun payload ->
     let headers = Auth.to_headers (module Cfg) payload in
-    let uri = Uri.make
-        ~scheme:"https"
-        ~host:Cfg.api_host
-        ~path
-        ?query:None
-        () in
-    Cohttp_async.Client.post
-      ~headers
-      ?chunked:None
-      ?interrupt:None
-      ?ssl_config:None
-      ?body:None
-      uri >>= fun (response, body) ->
+    let uri =
+      Uri.make ~scheme:"https" ~host:Cfg.api_host ~path ?query:None ()
+    in
+    Cohttp_async.Client.post ~headers ?chunked:None ?interrupt:None
+      ?ssl_config:None ?body:None uri
+    >>= fun (response, body) ->
     match Cohttp.Response.status response with
     | `OK ->
-      (
-        Cohttp_async.Body.to_string body
-        >>|
-        (fun s ->
-           Log.Global.debug "result as json:\n %s" s;
-           let yojson = Yojson.Safe.from_string s in
-           Response.parse yojson Operation.response_of_yojson
-        )
-      )
+        Cohttp_async.Body.to_string body >>| fun s ->
+        Log.Global.debug "result as json:\n %s" s;
+        let yojson = Yojson.Safe.from_string s in
+        Response.parse yojson Operation.response_of_yojson
     | `Not_found -> return `Not_found
     | `Not_acceptable ->
-      Cohttp_async.Body.to_string body >>| fun body ->
-      `Not_acceptable body
+        Cohttp_async.Body.to_string body >>| fun body -> `Not_acceptable body
     | `Bad_request ->
-      Cohttp_async.Body.to_string body >>| fun body ->
-      `Bad_request body
+        Cohttp_async.Body.to_string body >>| fun body -> `Bad_request body
     | `Service_unavailable ->
-      Cohttp_async.Body.to_string body >>| fun body ->
-     `Service_unavailable body
+        Cohttp_async.Body.to_string body >>| fun body ->
+        `Service_unavailable body
     | (code : Cohttp.Code.status_code) ->
-      Cohttp_async.Body.to_string body >>| fun body ->
-      failwiths ~here:[%here] (sprintf "unexpected status code (body=%S)" body)
-        code Cohttp.Code.sexp_of_status_code
+        Cohttp_async.Body.to_string body >>| fun body ->
+        failwiths ~here:[%here]
+          (sprintf "unexpected status code (body=%S)" body)
+          code Cohttp.Code.sexp_of_status_code
 end
 
-
-module Make(Operation:Operation.S) =
-struct
-  include Post(Operation)
-  let command =
-    let open Command.Let_syntax in
-    (Operation.name,
-     Command.async
-       ~summary:(Path.to_summary ~has_subnames:false Operation.path)
-       [%map_open
-         let config = Cfg.param
-         and request = anon ("request" %: sexp)
-         in
-         fun () ->
-           let request = Operation.request_of_sexp request in
-           Log.Global.info "request:\n %s"
-             (Operation.sexp_of_request request |> Sexp.to_string);
-           let config = Cfg.or_default config in
-           Nonce.File.(pipe ~init:default_filename)
-             () >>= fun nonce ->
-           post config nonce request >>= function
-           | `Ok response ->
-             Log.Global.info "response:\n %s"
-               (Sexp.to_string_hum
-                  (Operation.sexp_of_response response)
-               ); Log.Global.flushed ()
-           | #Error.post as post_error ->
-             failwiths
-               ~here:[%here]
-               (sprintf
-                  "post for operation %S failed"
-                  (Path.to_string Operation.path)
-               )
-               post_error
-               Error.sexp_of_post
-       ]
-    )
-
-end
-
-module Make_no_arg(Operation:Operation.S_NO_ARG) =
-struct
-  include Post(Operation)
+module Make (Operation : Operation.S) = struct
+  include Post (Operation)
 
   let command =
     let open Command.Let_syntax in
-    (Operation.name,
-     Command.async
-       ~summary:(Path.to_summary ~has_subnames:false Operation.path)
-       [%map_open
-         let config = Cfg.param in
-         fun () ->
-           let request = () in
-           let config = Cfg.or_default config in
-           Nonce.File.(pipe ~init:default_filename) () >>= fun nonce ->
-           post config nonce request >>= function
-           | `Ok response ->
-             Log.Global.info "response:\n %s"
-               (Sexp.to_string_hum
-                  (Operation.sexp_of_response response)
-               ); Log.Global.flushed ()
-           | #Error.post as post_error ->
-             failwiths
-               ~here:[%here]
-               (sprintf
-                  "post for operation %S failed"
-                  (Path.to_string Operation.path)
-               )
-               post_error
-               Error.sexp_of_post
-       ]
-    )
+    ( Operation.name,
+      Command.async
+        ~summary:(Path.to_summary ~has_subnames:false Operation.path)
+        [%map_open
+          let config = Cfg.param and request = anon ("request" %: sexp) in
+          fun () ->
+            let request = Operation.request_of_sexp request in
+            Log.Global.info "request:\n %s"
+              (Operation.sexp_of_request request |> Sexp.to_string);
+            let config = Cfg.or_default config in
+            Nonce.File.(pipe ~init:default_filename) () >>= fun nonce ->
+            post config nonce request >>= function
+            | `Ok response ->
+                Log.Global.info "response:\n %s"
+                  (Sexp.to_string_hum (Operation.sexp_of_response response));
+                Log.Global.flushed ()
+            | #Error.post as post_error ->
+                failwiths ~here:[%here]
+                  (sprintf "post for operation %S failed"
+                     (Path.to_string Operation.path))
+                  post_error Error.sexp_of_post] )
+end
 
+module Make_no_arg (Operation : Operation.S_NO_ARG) = struct
+  include Post (Operation)
+
+  let command =
+    let open Command.Let_syntax in
+    ( Operation.name,
+      Command.async
+        ~summary:(Path.to_summary ~has_subnames:false Operation.path)
+        [%map_open
+          let config = Cfg.param in
+          fun () ->
+            let request = () in
+            let config = Cfg.or_default config in
+            Nonce.File.(pipe ~init:default_filename) () >>= fun nonce ->
+            post config nonce request >>= function
+            | `Ok response ->
+                Log.Global.info "response:\n %s"
+                  (Sexp.to_string_hum (Operation.sexp_of_response response));
+                Log.Global.flushed ()
+            | #Error.post as post_error ->
+                failwiths ~here:[%here]
+                  (sprintf "post for operation %S failed"
+                     (Path.to_string Operation.path))
+                  post_error Error.sexp_of_post] )
 end

--- a/lib/rest.mli
+++ b/lib/rest.mli
@@ -5,130 +5,115 @@
     the REST services don't throw exceptions- instead they report an error
     variant with some provisional failure information. *)
 module Error : sig
-
+  type http =
+    [ `Bad_request of string
+    | `Not_found
+    | `Service_unavailable of string
+    | `Not_acceptable of string
+    | `Unauthorized of string ]
+  [@@deriving sexp]
   (** An error at the http protocol level. Each variant is named according
       to it's corresponding http status code. The body of the http response
       is append to the variant payload if it exists. *)
-  type http = [ `Bad_request of string
-              | `Not_found
-              | `Service_unavailable of string
-              | `Not_acceptable of string
-              | `Unauthorized of string] [@@deriving sexp]
 
+  type json_error = { message : string; body : string } [@@deriving sexp]
   (** An error type indicating a json parse error. *)
-  type json_error = {message:string;body:string} [@@deriving sexp]
 
+  type json = [ `Json_parse_error of json_error ] [@@deriving sexp]
   (** Json level error conditions. *)
-  type json = [`Json_parse_error of json_error] [@@deriving sexp]
 
+  type detail = { reason : string; message : string } [@@deriving sexp, yojson]
   (** Used to provide more details on a particular error condition *)
-  type detail = {reason:string;message:string} [@@deriving sexp, yojson]
 
+  type response = [ `Error of detail ] [@@deriving sexp]
   (** Application level error conditions *)
-  type response = [`Error of detail] [@@deriving sexp]
 
+  type post = [ http | json | response ] [@@deriving sexp]
   (** Any error condition possible from an http post request *)
-  type post = [http|json|response] [@@deriving sexp]
 end
 
 module Request = Nonce.Request
 
-
 (** Operations denote a single REST operation endpoint. *)
 module Operation : sig
-
   (** Minimal specification to define a new REST operation. *)
   module type S = sig
-
-    (** The human readable name of this operation. *)
     val name : string
+    (** The human readable name of this operation. *)
 
-    (** The uri path of the REST endpoint. *)
     val path : string list
+    (** The uri path of the REST endpoint. *)
 
-    (** The type of the request payload for this REST endpoint. *)
     type request [@@deriving sexp, to_yojson]
+    (** The type of the request payload for this REST endpoint. *)
 
-    (** The type of the response payload for this REST endpoint. *)
     type response [@@deriving sexp, of_yojson]
+    (** The type of the response payload for this REST endpoint. *)
   end
 
   (** A REST operation endpoint which takes no request parameters. *)
   module type S_NO_ARG = sig
     include S with type request = unit
   end
-
 end
 
 (** Support for parsing responses from a Gemini api REST endpoint. *)
-module Response :
-sig
-  module Json_result :
-  sig
+module Response : sig
+  module Json_result : sig
     type t = [ `Error | `Ok ] [@@derivin sexp, yojson, enumerate]
+
     val to_string : t -> string
     val dict : (string * t) list
     val of_string : string -> t
     val of_string_opt : string -> t option
-     val split :
-      [< Yojson.Safe.t ] ->
-      (t option * [> Yojson.Safe.t ], string) result
+
+    val split :
+      [< Yojson.Safe.t ] -> (t option * [> Yojson.Safe.t ], string) result
   end
-  type result_field =
-    { result : Json_result.t; } [@@deriving sexp, of_yojson]
-  type t =
-    { result : Json_result.t; payload : Yojson.Safe.t; }
+
+  type result_field = { result : Json_result.t } [@@deriving sexp, of_yojson]
+  type t = { result : Json_result.t; payload : Yojson.Safe.t }
+
   val parse :
     Yojson.Safe.t ->
     ([> Yojson.Safe.t ] -> ('a, string) result) ->
     [ `Error of Error.detail
     | `Json_parse_error of Error.json_error
-    | `Ok of 'a
-    ]
+    | `Ok of 'a ]
 end
 
 (** Creates a REST endpoint using the http post method with
     operation specified by provided module [Operation] *)
-module Post :
-  functor (Operation : Operation.S) ->
-  sig
-    val post :
-      (module Cfg.S) ->
-      Nonce.reader ->
-      Operation.request ->
-      [ `Ok of Operation.response
-      | Error.post
-      ] Deferred.t
-  end
+module Post : functor (Operation : Operation.S) -> sig
+  val post :
+    (module Cfg.S) ->
+    Nonce.reader ->
+    Operation.request ->
+    [ `Ok of Operation.response | Error.post ] Deferred.t
+end
 
 (** Creates a REST endpoint using the http post method with
     operation specified by provided module [Operation].
     Also produces a command line interface hook. *)
-module Make :
-  functor (Operation : Operation.S) ->
-  sig
-    val post :
-      (module Cfg.S) ->
-      Nonce.reader ->
-      Operation.request ->
-      [`Ok of Operation.response
-      | Error.post
-      ] Deferred.t
-    val command : string * Core.Command.t
-  end
+module Make : functor (Operation : Operation.S) -> sig
+  val post :
+    (module Cfg.S) ->
+    Nonce.reader ->
+    Operation.request ->
+    [ `Ok of Operation.response | Error.post ] Deferred.t
+
+  val command : string * Core.Command.t
+end
 
 (** Creates a REST endpoint using the http post method with no argument
     operation specified by provided module [Operation].
     Also produces a command line interface hook. *)
-module Make_no_arg :
-  functor (Operation : Operation.S_NO_ARG) ->
-  sig
-    val post :
-      (module Cfg.S) ->
-      Nonce.reader ->
-      unit ->
-      [ Error.post
-      | `Ok of Operation.response
-      ] Deferred.t
-    val command : string * Core.Command.t
-  end
+module Make_no_arg : functor (Operation : Operation.S_NO_ARG) -> sig
+  val post :
+    (module Cfg.S) ->
+    Nonce.reader ->
+    unit ->
+    [ Error.post | `Ok of Operation.response ] Deferred.t
+
+  val command : string * Core.Command.t
+end

--- a/lib/ws.ml
+++ b/lib/ws.ml
@@ -41,7 +41,7 @@ end) : CSV_OF_EVENTS with module Event_type = Event_type = struct
   module Event_type = Event_type
 
   let add (t : t) (event_type : Event_type.t) (module Event : EVENT_CSVABLE) =
-    Event_type.Map.add_multi t ~key:event_type
+    Map.add_multi t ~key:event_type
       ~data:(module Event : EVENT_CSVABLE)
 
   let add' (t : t) (type event) (event_type : Event_type.t)
@@ -54,23 +54,23 @@ end) : CSV_OF_EVENTS with module Event_type = Event_type = struct
     add t event_type (module E)
 
   let csv_header (t : t) event_type =
-    Event_type.Map.find_multi t event_type
+    Map.find_multi t event_type
     |> List.hd
     |> Option.map ~f:(fun (module Event : EVENT_CSVABLE) -> Event.csv_header)
 
   let get (t : t) (event_type : Event_type.t) =
-    Event_type.Map.find_multi t event_type
+    Map.find_multi t event_type
     |> List.concat_map ~f:(fun (module Event : EVENT_CSVABLE) ->
            Event.events |> List.map ~f:Event.row_of_t)
 
   let write ?dir (t : t) (event_type : Event_type.t) =
-    let dir = match dir with None -> Core.Unix.getcwd () | Some dir -> dir in
+    let dir = match dir with None -> Core_unix.getcwd () | Some dir -> dir in
     let filename =
       Filename.concat dir (sprintf "%s.csv" (Event_type.to_string event_type))
     in
     let header =
       try
-        let stat = Core.Unix.stat filename in
+        let stat = Core_unix.stat filename in
         if Int64.(equal stat.st_size zero) then csv_header t event_type
         else (
           Log.Global.debug "ws: no csv header";
@@ -84,7 +84,7 @@ end) : CSV_OF_EVENTS with module Event_type = Event_type = struct
       filename ~f:(fun out ->
         Option.iter header ~f:(fun header ->
             Csv_support.write_header out header);
-        Event_type.Map.find_multi t event_type
+        Map.find_multi t event_type
         |> List.fold ~init:0 ~f:(fun acc (module Event : EVENT_CSVABLE) ->
                let events = Event.events in
                let len = List.length events in
@@ -162,10 +162,10 @@ module Impl (Channel : CHANNEL) = struct
       Option.map query ~f:(fun l ->
           List.fold ~init:String.Map.empty l ~f:(fun map q ->
               let key, data = Channel.encode_query (Channel.query_of_sexp q) in
-              String.Map.add_multi map ~key ~data)
+              Map.add_multi map ~key ~data)
           |> fun map ->
-          let keys = String.Map.keys map in
-          List.map keys ~f:(fun k -> (k, String.Map.find_multi map k)))
+          let keys = Map.keys map in
+          List.map keys ~f:(fun k -> (k, Map.find_multi map k)))
     in
     let uri =
       Uri.make ~host:Cfg.api_host ~scheme:"https" ?query

--- a/lib/ws.ml
+++ b/lib/ws.ml
@@ -4,424 +4,353 @@ module type CSVABLE = Csvfields.Csv.Csvable
 
 module type EVENT_CSVABLE = sig
   include CSVABLE
+
   val events : t list
 end
 
-module type CSV_OF_EVENTS =
-sig
-  module Event_type : sig include Json.S val equal : t -> t -> bool end
+module type CSV_OF_EVENTS = sig
+  module Event_type : sig
+    include Json.S
+
+    val equal : t -> t -> bool
+  end
+
   type t
+
   val empty : t
-  val add :
-    t ->
-    Event_type.t ->
-    (module EVENT_CSVABLE) ->
-    t
+  val add : t -> Event_type.t -> (module EVENT_CSVABLE) -> t
 
   val add' :
-    t ->
-    Event_type.t ->
-    (module CSVABLE with type t = 'a) ->
-    'a list -> t
+    t -> Event_type.t -> (module CSVABLE with type t = 'a) -> 'a list -> t
 
-  val csv_header :
-    t ->
-    Event_type.t -> string list option
-
+  val csv_header : t -> Event_type.t -> string list option
   val get : t -> Event_type.t -> string list list
   val all : t -> (Event_type.t * string list list) list
-
- val write :
-   ?dir:string -> t -> Event_type.t -> int
-
- val write_all :
-   ?dir:string -> t -> (Event_type.t * int) list
+  val write : ?dir:string -> t -> Event_type.t -> int
+  val write_all : ?dir:string -> t -> (Event_type.t * int) list
 end
 
-module Csv_of_event(
-    Event_type :
-    sig
-      include Json.S
-      include Comparable with type t := t
-    end) : CSV_OF_EVENTS with module Event_type = Event_type =
-struct
-  type t =
-    (module EVENT_CSVABLE) list Event_type.Map.t
+module Csv_of_event (Event_type : sig
+  include Json.S
+  include Comparable with type t := t
+end) : CSV_OF_EVENTS with module Event_type = Event_type = struct
+  type t = (module EVENT_CSVABLE) list Event_type.Map.t
 
   let empty : t = Event_type.Map.empty
+
   module Event_type = Event_type
 
-  let add (t:t)
-     (event_type : Event_type.t)
-     (module Event : EVENT_CSVABLE) =
+  let add (t : t) (event_type : Event_type.t) (module Event : EVENT_CSVABLE) =
     Event_type.Map.add_multi t ~key:event_type
       ~data:(module Event : EVENT_CSVABLE)
 
-  let add' (t:t)
-      (type event)
-      (event_type : Event_type.t)
-      (module Event : CSVABLE with type t = event)
-      (events:event list) =
-    let module E = struct include Event let events = events end in
+  let add' (t : t) (type event) (event_type : Event_type.t)
+      (module Event : CSVABLE with type t = event) (events : event list) =
+    let module E = struct
+      include Event
+
+      let events = events
+    end in
     add t event_type (module E)
 
-  let csv_header (t:t) event_type =
-    Event_type.Map.find_multi t event_type |>
-    List.hd |>
-    Option.map
-      ~f:(fun (module Event : EVENT_CSVABLE) -> Event.csv_header)
+  let csv_header (t : t) event_type =
+    Event_type.Map.find_multi t event_type
+    |> List.hd
+    |> Option.map ~f:(fun (module Event : EVENT_CSVABLE) -> Event.csv_header)
 
-  let get (t:t) (event_type:Event_type.t) =
-    Event_type.Map.find_multi t event_type |>
-    List.concat_map ~f:
-      (fun (module Event : EVENT_CSVABLE) ->
-         Event.events |> List.map ~f:Event.row_of_t
-      )
+  let get (t : t) (event_type : Event_type.t) =
+    Event_type.Map.find_multi t event_type
+    |> List.concat_map ~f:(fun (module Event : EVENT_CSVABLE) ->
+           Event.events |> List.map ~f:Event.row_of_t)
 
-  let write
-      ?dir (t:t) (event_type:Event_type.t) =
-    let dir = match dir with
-      | None -> Core.Unix.getcwd ()
-      | Some dir -> dir in
-    let filename = Filename.concat
-        dir
-        (sprintf "%s.csv" (Event_type.to_string event_type))
+  let write ?dir (t : t) (event_type : Event_type.t) =
+    let dir = match dir with None -> Core.Unix.getcwd () | Some dir -> dir in
+    let filename =
+      Filename.concat dir (sprintf "%s.csv" (Event_type.to_string event_type))
     in
     let header =
       try
         let stat = Core.Unix.stat filename in
-        if Int64.(equal stat.st_size zero) then
-          csv_header t event_type
-        else
-          (
-            Log.Global.debug "ws: no csv header";
-            None
-          )
-      with
-      | _error -> (* This looks confusing, simplify or document *)
+        if Int64.(equal stat.st_size zero) then csv_header t event_type
+        else (
+          Log.Global.debug "ws: no csv header";
+          None)
+      with _error ->
+        (* This looks confusing, simplify or document *)
         Log.Global.debug "ws: getting csv header";
-        csv_header t event_type in
-    Out_channel.with_file
-      ~append:true
-      ~binary:false
-      ~fail_if_exists:false
-      filename
-      ~f:
-        (fun out ->
-           Option.iter header ~f:
-             (fun header ->
-                Csv_support.write_header out header
-             );
-           Event_type.Map.find_multi t event_type |>
-           List.fold ~init:0
-             ~f:
-               (fun acc (module Event : EVENT_CSVABLE) ->
-                  let events = Event.events in
-                  let len = List.length events in
-                  Event.csv_save_out out events;
-                  acc + len
-               )
-        )
+        csv_header t event_type
+    in
+    Out_channel.with_file ~append:true ~binary:false ~fail_if_exists:false
+      filename ~f:(fun out ->
+        Option.iter header ~f:(fun header ->
+            Csv_support.write_header out header);
+        Event_type.Map.find_multi t event_type
+        |> List.fold ~init:0 ~f:(fun acc (module Event : EVENT_CSVABLE) ->
+               let events = Event.events in
+               let len = List.length events in
+               Event.csv_save_out out events;
+               acc + len))
 
-  let all (t:t) =
-    List.filter_map Event_type.all
-      ~f:
-        (fun e -> match (get t e) with
-          | [] -> None
-          | x -> Some (e,x)
-        )
+  let all (t : t) =
+    List.filter_map Event_type.all ~f:(fun e ->
+        match get t e with [] -> None | x -> Some (e, x))
 
-  let write_all ?dir (t:t) =
-    List.map Event_type.all
-      ~f:(fun e -> e, write ?dir t e)
+  let write_all ?dir (t : t) =
+    List.map Event_type.all ~f:(fun e -> (e, write ?dir t e))
 end
 
 (** Specification for a websocket channel. *)
 module type CHANNEL = sig
-  (** The name of the channel *)
   val name : string
+  (** The name of the channel *)
 
-  (** The channel protocol version *)
   val version : string
+  (** The channel protocol version *)
 
-  (** The uri path for this channel *)
   val path : string list
+  (** The uri path for this channel *)
 
+  val authentication : [ `Private | `Public ]
   (** Authentication syle for this channel. One of
       [`Private] or [`Public]
   *)
-  val authentication : [`Private | `Public]
 
+  type uri_args [@@deriving sexp, enumerate]
   (** Uri arguments which are appended to the end of
       the path segment *)
-  type uri_args [@@deriving sexp, enumerate]
 
+  val encode_uri_args : uri_args -> string
   (** Encder from well typed uri arguments to a string
       suitable for a uri.
   *)
-  val encode_uri_args : uri_args -> string
 
-  (** Defaut uri arguments. Optional for some channels. *)
   val default_uri_args : uri_args option
+  (** Defaut uri arguments. Optional for some channels. *)
 
+  type response [@@deriving sexp, of_yojson]
   (** Respone type of the channel. Must have sexp converters
       and a yojson parser *)
-  type response [@@deriving sexp, of_yojson]
 
+  module Event_type : sig
+    include Json.S
 
-  module Event_type :
-   sig include Json.S val equal : t -> t -> bool end
+    val equal : t -> t -> bool
+  end
 
-  module Csv_of_event :
-    CSV_OF_EVENTS with module Event_type = Event_type
+  module Csv_of_event : CSV_OF_EVENTS with module Event_type = Event_type
 
+  val events_of_response : response -> Csv_of_event.t
   (** Given a response value produce csvable events
       modularized by event type. *)
-  val events_of_response :
-    response -> Csv_of_event.t
 
-  (** Query parameters for the channel *)
   type query [@@deriving sexp]
+  (** Query parameters for the channel *)
 
-  (** Encodes queries as an http header key value pair *)
   val encode_query : query -> string * string
+  (** Encodes queries as an http header key value pair *)
 end
 
 (** Creates a websocket implementation given a [Channel] *)
-module Impl(Channel : CHANNEL) =
-struct
-
-(** Establishes a web socket client given configuration [Cfg]
+module Impl (Channel : CHANNEL) = struct
+  (** Establishes a web socket client given configuration [Cfg]
     and optional [query], [uri_args] and [nonce] parameters.
 
     Produces a pipe of [Channel.response] instances.
 *)
-let client (module Cfg : Cfg.S)
-    ?query ?uri_args ?nonce
-    () =
-  let query =
-    Option.map query
-      ~f:
-        (fun l -> List.fold ~init:String.Map.empty l
-           ~f:(fun map q ->
-               let key, data =
-                 Channel.encode_query (Channel.query_of_sexp q) in
-               String.Map.add_multi map ~key ~data
-              )
-        |> fun map ->
-        let keys = String.Map.keys map in
-        List.map keys ~f:(fun k -> k, String.Map.find_multi map k)
-        ) in
-  let uri = Uri.make
-      ~host:Cfg.api_host
-      ~scheme:"https"
-      ?query
-      ~path:
-        (String.concat ~sep:"/"
-           (Channel.path
-            @
-            Option.(map ~f:(Channel.encode_uri_args) uri_args |> to_list)
-           )
-        )
-      ()
-      in
-  Log.Global.info "Ws.client: uri=%s"
-    (Uri.to_string uri);
-  let host = Option.value_exn ~message:"no host in uri"
-      Uri.(host uri) in
-  let port = Option.value ~default:443
-      Uri_services.(tcp_port_of_uri uri) in
-  let scheme = Option.value ~default:"wss"
-      Uri.(scheme uri) in
-  let tcp_fun s r w =
-    Socket.(setopt s Opt.nodelay true);
-    (if String.(equal scheme "https" || equal scheme "wss") then
-       (Unix.Inet_addr.of_string_or_getbyname host >>|
-        Ipaddr_unix.of_inet_addr
-       ) >>= fun addr ->
-       Conduit_async.
-         (connect
-            (`OpenSSL_with_config
-               (
-                 "wss",
-                 addr,
-                 port,
-                 Ssl.configure ~version:Tlsv1_2 ()
-               )
-            )
-         )
-     else return (r, w)
-    ) >>= fun (r, w) ->
-    let payload = `Null in
-    let path = Path.to_string Channel.path in
-    let%bind payload =
-      match nonce with
-      | None -> return None
-      | Some nonce ->
-      Nonce.Request.
-        (make ~nonce ~request:path ~payload () >>|
-         to_yojson
-        )
-      >>| fun s -> Yojson.Safe.to_string s |> Option.some in
-    let extra_headers =
-      (match Channel.authentication with
-      | `Private ->
-        Option.map ~f:(fun p -> Auth.(to_headers (module Cfg) (of_payload p))) payload
-      | `Public -> None
-      )
-      |> Option.value ~default:(Cohttp.Header.init ()) in
-    let r, _w = Websocket_async.client_ez
-        ~extra_headers
-        ~heartbeat:Time_ns.Span.(of_int_sec 5)
-        uri r w
+  let client (module Cfg : Cfg.S) ?query ?uri_args ?nonce () =
+    let query =
+      Option.map query ~f:(fun l ->
+          List.fold ~init:String.Map.empty l ~f:(fun map q ->
+              let key, data = Channel.encode_query (Channel.query_of_sexp q) in
+              String.Map.add_multi map ~key ~data)
+          |> fun map ->
+          let keys = String.Map.keys map in
+          List.map keys ~f:(fun k -> (k, String.Map.find_multi map k)))
     in
-    Log.Global.info "input pipe established for channel %s" Channel.name;
-    Log.Global.flushed () >>| fun () ->
-      (Pipe.map r
-      ~f:
-        (fun s ->
-           Yojson.Safe.from_string s
-           |> Channel.response_of_yojson
-           |> Result.ok_or_failwith
-        )
-      )
-  in
-  let hostport = Host_and_port.create ~host ~port in
-  Tcp.(with_connection Where_to_connect.(of_host_and_port hostport) tcp_fun)
-
-let handle_client addr reader writer =
-  let addr_str = Socket.Address.(to_string addr) in
-  Log.Global.info "Client connection from %s" addr_str;
-  let app_to_ws, sender_write = Pipe.create () in
-  let receiver_read, ws_to_app = Pipe.create () in
-  let check_request req =
-    let req_str = Format.asprintf "%a" Cohttp.Request.pp_hum req in
-    Log.Global.info "Incoming connnection request: %s" req_str ;
-    let path = Cohttp.Request.uri req |> Uri.path in
-    Deferred.return (String.equal path "/ws")
-  in
-  let rec loop () =
-    Pipe.read receiver_read >>= function
-    | `Eof ->
-      Log.Global.info "Client %s disconnected" addr_str;
-      Deferred.unit
-    | `Ok ({ Websocket_async.Frame.opcode;
-             extension=_; final=_; content } as frame
-          ) ->
-      let open Websocket_async.Frame in
-      Log.Global.debug "<- %s" (show frame);
-      let frame', closed =
-        match opcode with
-        | Opcode.Ping -> Some (create ~opcode:Opcode.Pong ~content ()), false
-        | Opcode.Close ->
-          (* Immediately echo and pass this last message to the user *)
-          if String.length content >= 2 then
-            Some (create ~opcode:Opcode.Close
-                          ~content:(String.sub content ~pos:0 ~len:2) ()), true
-          else
-          Some (close 100), true
-        | Opcode.Pong -> None, false
-        | Opcode.Text
-        | Opcode.Binary -> Some frame, false
-        | _ -> Some (close 1002), false
+    let uri =
+      Uri.make ~host:Cfg.api_host ~scheme:"https" ?query
+        ~path:
+          (String.concat ~sep:"/"
+             (Channel.path
+             @ Option.(map ~f:Channel.encode_uri_args uri_args |> to_list)))
+        ()
+    in
+    Log.Global.info "Ws.client: uri=%s" (Uri.to_string uri);
+    let host = Option.value_exn ~message:"no host in uri" Uri.(host uri) in
+    let port = Option.value ~default:443 Uri_services.(tcp_port_of_uri uri) in
+    let scheme = Option.value ~default:"wss" Uri.(scheme uri) in
+    let tcp_fun s r w =
+      Socket.(setopt s Opt.nodelay true);
+      (if String.(equal scheme "https" || equal scheme "wss") then
+         Unix.Inet_addr.of_string_or_getbyname host >>| Ipaddr_unix.of_inet_addr
+         >>= fun addr ->
+         Conduit_async.(
+           connect
+             (`OpenSSL_with_config
+               ("wss", addr, port, Ssl.configure ~version:Tlsv1_2 ())))
+       else return (r, w))
+      >>= fun (r, w) ->
+      let payload = `Null in
+      let path = Path.to_string Channel.path in
+      let%bind payload =
+        match nonce with
+        | None -> return None
+        | Some nonce ->
+            Nonce.Request.(make ~nonce ~request:path ~payload () >>| to_yojson)
+            >>| fun s -> Yojson.Safe.to_string s |> Option.some
       in
-      begin
-        match frame' with
-        | None ->
-          Deferred.unit
-        | Some frame' ->
-          Log.Global.debug "-> %s" (show frame');
-          Pipe.write sender_write frame'
-      end >>= fun () ->
-      if closed then Deferred.unit
-      else loop ()
-  in
-  Deferred.any [
-    begin Websocket_async.server
-        ~check_request ~app_to_ws ~ws_to_app ~reader ~writer () >>= function
-      | Error err ->
-         (match Error.to_exn err with 
-          | Exit -> Deferred.unit
-          | (_:Exn.t) -> Error.raise err
-         )
-      | Ok () -> Deferred.unit
-    end ;
-    loop () ;
-  ]
+      let extra_headers =
+        (match Channel.authentication with
+        | `Private ->
+            Option.map
+              ~f:(fun p -> Auth.(to_headers (module Cfg) (of_payload p)))
+              payload
+        | `Public -> None)
+        |> Option.value ~default:(Cohttp.Header.init ())
+      in
+      let r, _w =
+        Websocket_async.client_ez ~extra_headers
+          ~heartbeat:Time_ns.Span.(of_int_sec 5)
+          uri r w
+      in
+      Log.Global.info "input pipe established for channel %s" Channel.name;
+      Log.Global.flushed () >>| fun () ->
+      Pipe.map r ~f:(fun s ->
+          Yojson.Safe.from_string s |> Channel.response_of_yojson
+          |> Result.ok_or_failwith)
+    in
+    let hostport = Host_and_port.create ~host ~port in
+    Tcp.(with_connection Where_to_connect.(of_host_and_port hostport) tcp_fun)
 
-let command =
-  let spec : (_,_) Command.Spec.t =
-    let open Command.Spec in
-    empty
-    +> Cfg.param
-    +> flag "-loglevel" (optional int) ~doc:"1-3 loglevel"
-    +> flag "-query" (listed sexp) ~doc:"QUERY query parameters"
-    +> flag "-csv-dir" (optional string)
-      ~doc:"PATH output each event type to a separate csv file at PATH. \
-             Defaults to current directory."
-    +> anon (maybe ("uri_args" %: sexp))
- in
-  let set_loglevel = function
-    | 2 -> Log.Global.set_level `Info
-    | 3 -> Log.Global.set_level `Debug
-    | _ -> ()
-  in
-  let run cfg
-      loglevel query (csv_dir:string option) uri_args () =
-    let cfg = Cfg.or_default cfg in
-    let module Cfg = (val cfg:Cfg.S) in
-    Option.iter loglevel ~f:set_loglevel;
-    let uri_args =
-      Option.first_some
-        (Option.map ~f:Channel.uri_args_of_sexp uri_args)
-        Channel.default_uri_args in
-    let query = match List.is_empty query with
-      | true -> None
-      | false -> Some query in
-    let%bind nonce =
-      Nonce.File.(pipe ~init:default_filename) () in
-    Log.Global.info "Initiating channel %s with path %s"
-      Channel.name (Path.to_string Channel.path);
-    let channel_to_sexp_str response =
-      Channel.sexp_of_response response |>
-      Sexp.to_string_hum |>
-      sprintf "%s\n" in
-    let append_to_csv response =
-      let events = Channel.events_of_response response in
-      let all = Channel.Csv_of_event.write_all ?dir:csv_dir events in
-      let tags = List.map all ~f:(fun (k, v) ->
-          Channel.Event_type.to_string k,
-          Int.to_string v
-        ) in
-      Log.Global.debug ~tags "wrote csv response events";
-      () in
-    let pipe_reader response =
-      append_to_csv response;
-      channel_to_sexp_str response in
-    client (module Cfg)
-      ?query ?uri_args ~nonce () >>= fun pipe ->
-    Log.Global.debug "Broadcasting channel %s to stderr..." Channel.name;
-      Pipe.transfer pipe
-        Writer.(pipe (Lazy.force stderr))
-        ~f:pipe_reader
-  in
-  Channel.name,
-  Command.async_spec
-    ~summary:(sprintf "Gemini %s %s Websocket Command"
-                Channel.version Channel.name
-             ) spec run
+  let handle_client addr reader writer =
+    let addr_str = Socket.Address.(to_string addr) in
+    Log.Global.info "Client connection from %s" addr_str;
+    let app_to_ws, sender_write = Pipe.create () in
+    let receiver_read, ws_to_app = Pipe.create () in
+    let check_request req =
+      let req_str = Format.asprintf "%a" Cohttp.Request.pp_hum req in
+      Log.Global.info "Incoming connnection request: %s" req_str;
+      let path = Cohttp.Request.uri req |> Uri.path in
+      Deferred.return (String.equal path "/ws")
+    in
+    let rec loop () =
+      Pipe.read receiver_read >>= function
+      | `Eof ->
+          Log.Global.info "Client %s disconnected" addr_str;
+          Deferred.unit
+      | `Ok
+          ({ Websocket_async.Frame.opcode; extension = _; final = _; content }
+          as frame) ->
+          let open Websocket_async.Frame in
+          Log.Global.debug "<- %s" (show frame);
+          let frame', closed =
+            match opcode with
+            | Opcode.Ping ->
+                (Some (create ~opcode:Opcode.Pong ~content ()), false)
+            | Opcode.Close ->
+                (* Immediately echo and pass this last message to the user *)
+                if String.length content >= 2 then
+                  ( Some
+                      (create ~opcode:Opcode.Close
+                         ~content:(String.sub content ~pos:0 ~len:2)
+                         ()),
+                    true )
+                else (Some (close 100), true)
+            | Opcode.Pong -> (None, false)
+            | Opcode.Text | Opcode.Binary -> (Some frame, false)
+            | _ -> (Some (close 1002), false)
+          in
+          (match frame' with
+          | None -> Deferred.unit
+          | Some frame' ->
+              Log.Global.debug "-> %s" (show frame');
+              Pipe.write sender_write frame')
+          >>= fun () -> if closed then Deferred.unit else loop ()
+    in
+    Deferred.any
+      [
+        (Websocket_async.server ~check_request ~app_to_ws ~ws_to_app ~reader
+           ~writer ()
+         >>= function
+         | Error err -> (
+             match Error.to_exn err with
+             | Exit -> Deferred.unit
+             | (_ : Exn.t) -> Error.raise err)
+         | Ok () -> Deferred.unit);
+        loop ();
+      ]
+
+  let command =
+    let spec : (_, _) Command.Spec.t =
+      let open Command.Spec in
+      empty +> Cfg.param
+      +> flag "-loglevel" (optional int) ~doc:"1-3 loglevel"
+      +> flag "-query" (listed sexp) ~doc:"QUERY query parameters"
+      +> flag "-csv-dir" (optional string)
+           ~doc:
+             "PATH output each event type to a separate csv file at PATH. \
+              Defaults to current directory."
+      +> anon (maybe ("uri_args" %: sexp))
+    in
+    let set_loglevel = function
+      | 2 -> Log.Global.set_level `Info
+      | 3 -> Log.Global.set_level `Debug
+      | _ -> ()
+    in
+    let run cfg loglevel query (csv_dir : string option) uri_args () =
+      let cfg = Cfg.or_default cfg in
+      let module Cfg = (val cfg : Cfg.S) in
+      Option.iter loglevel ~f:set_loglevel;
+      let uri_args =
+        Option.first_some
+          (Option.map ~f:Channel.uri_args_of_sexp uri_args)
+          Channel.default_uri_args
+      in
+      let query =
+        match List.is_empty query with true -> None | false -> Some query
+      in
+      let%bind nonce = Nonce.File.(pipe ~init:default_filename) () in
+      Log.Global.info "Initiating channel %s with path %s" Channel.name
+        (Path.to_string Channel.path);
+      let channel_to_sexp_str response =
+        Channel.sexp_of_response response
+        |> Sexp.to_string_hum |> sprintf "%s\n"
+      in
+      let append_to_csv response =
+        let events = Channel.events_of_response response in
+        let all = Channel.Csv_of_event.write_all ?dir:csv_dir events in
+        let tags =
+          List.map all ~f:(fun (k, v) ->
+              (Channel.Event_type.to_string k, Int.to_string v))
+        in
+        Log.Global.debug ~tags "wrote csv response events";
+        ()
+      in
+      let pipe_reader response =
+        append_to_csv response;
+        channel_to_sexp_str response
+      in
+      client (module Cfg) ?query ?uri_args ~nonce () >>= fun pipe ->
+      Log.Global.debug "Broadcasting channel %s to stderr..." Channel.name;
+      Pipe.transfer pipe Writer.(pipe (Lazy.force stderr)) ~f:pipe_reader
+    in
+    ( Channel.name,
+      Command.async_spec
+        ~summary:
+          (sprintf "Gemini %s %s Websocket Command" Channel.version Channel.name)
+        spec run )
 end
 
 (** Create a websocket interface that has no request parameters *)
-module Make_no_request(Channel:CHANNEL) =
-struct
-  include Impl(Channel)
+module Make_no_request (Channel : CHANNEL) = struct
+  include Impl (Channel)
+
   let client = client ?nonce:None
 end
 
 (** Create a websocket interface with request parameters *)
-module Make(Channel:CHANNEL) =
-struct
-  include Impl(Channel)
+module Make (Channel : CHANNEL) = struct
+  include Impl (Channel)
+
   let client ~nonce = client ~nonce
 end

--- a/src/gemini/auth.ml
+++ b/src/gemini/auth.ml
@@ -1,0 +1,30 @@
+type t = [ `Base64 of Cstruct.t | Hex.t ]
+(** An authentication token type. *)
+
+(** Given a base64 payload, produce an authentication token. *)
+let of_payload s : [< t > `Base64 ] =
+  `Base64 (Cstruct.of_string s |> Nocrypto.Base64.encode)
+
+let hmac_sha384 ~api_secret (`Base64 payload) : [< t > `Hex ] =
+  let key = Cstruct.of_string api_secret in
+  Nocrypto.Hash.SHA384.hmac ~key payload |> Hex.of_cstruct
+
+(** Produce a string representation of the authentication token. *)
+let to_string : [< t ] -> string = function
+  | `Base64 cstruct -> Cstruct.to_string cstruct
+  | `Hex hex -> hex
+
+(** Encode an authentication token as a gemini payload with
+    an http header encoding. Use module [Cfg] to determine
+    secrets and the api target. *)
+let to_headers (module Cfg : Cfg.S) t =
+  Cohttp.Header.of_list
+    [
+      ("Content-Type", "text/plain");
+      ("Content-Length", "0");
+      ("Cache-Control", "no-cache");
+      ("X-GEMINI-PAYLOAD", to_string t);
+      ("X-GEMINI-APIKEY", Cfg.api_key);
+      ( "X-GEMINI-SIGNATURE",
+        hmac_sha384 ~api_secret:Cfg.api_secret t |> to_string );
+    ]

--- a/src/gemini/cfg.ml
+++ b/src/gemini/cfg.ml
@@ -1,0 +1,115 @@
+let create_config_dir () =
+  let dirname = sprintf "%s/%s" (Unix.getenv_exn "HOME") ".gemini" in
+  try_with ~extract_exn:true (fun () -> Unix.mkdir ?p:None ?perm:None dirname)
+  >>= function
+  | Result.Ok () -> Deferred.unit
+  | Result.Error (Unix.Unix_error (Unix.Error.EEXIST, _, _)) -> Deferred.unit
+  | Result.Error e ->
+      Log.Global.error
+        "failed to create gemini config directory\n        at %S." dirname;
+      raise e
+
+let param ?default ~name ~env () =
+  let name = sprintf "GEMINI_%s_%s" (String.uppercase env) name in
+  match Unix.getenv name with
+  | Some param -> param
+  | None -> (
+      match default with
+      | None ->
+          failwithf "Environment variable \"%s\" must be specified" name ()
+      | Some default -> default)
+
+let host ~env =
+  let env = String.lowercase env in
+  match env with
+  | "production" -> sprintf "api.gemini.com"
+  | _ -> sprintf "api.%s.gemini.com" env
+
+let version_1 = "v1"
+
+(** Gemini configuration. These values are the only
+    necessary parameters and secrets to connect to an endpoint.
+
+    For each gemini environment a different configuration module
+    should be instantiated. *)
+module type S = sig
+  val version : string
+  val api_host : string
+  val api_key : string
+  val api_secret : string
+end
+
+let api_key = param ~name:"API_KEY"
+let api_secret = param ~name:"API_SECRET"
+
+(** Makes a configuration module given a desired
+    Gemini environment. It then infers the values from
+    environment variables.
+
+    Any required fields not specified will generate a runtime error.
+*)
+let make env =
+  let module M = struct
+    let env = env
+    let version = version_1
+    let api_host = host ~env
+    let api_key = api_key ~env ()
+    let api_secret = api_secret ~env ()
+  end in
+  (module M : S)
+
+(** Creates a configuration module for the sandbox environment.
+    Will query the unix environment for the necessary parameters.
+
+    It is recommended to generate this module exactly once in your
+    program. *)
+module Sandbox () = struct
+  include (val make "sandbox" : S)
+end
+
+(** Creates a configuration module for the production environment.
+    Will query the unix environment for the necessary parameters.
+
+    It is recommended to generate this module exactly once in your
+    program. *)
+module Production () = struct
+  include (val make "production" : S)
+end
+
+(** Produces a configuration module given a string environment name
+    which should be one of "production" or "sandbox".
+*)
+let of_string s =
+  match String.lowercase s with
+  | "production" ->
+      let module Cfg : S = Production () in
+      (module Cfg : S)
+  | "sandbox" ->
+      let module Cfg : S = Sandbox () in
+      (module Cfg : S)
+  | unsupported_env ->
+      failwithf "environment %s not supported" unsupported_env ()
+
+let arg_type = Command.Arg_type.create of_string
+
+let param =
+  Command.Param.(
+    flag "-cfg" (optional arg_type)
+      ~doc:
+        (sprintf
+           "STRING the configuration the client will connect with (eg. sandbox \
+            or production. defaults to sandbox). Use GEMINI_ENV to override \
+            the default value."))
+
+(** Ensures a configuration chosen given an optional configuration module,
+    usually provided from the command line. If the module is
+    provided, it returns it unwrapped. Otherwise the unix environment is
+    queried to produce a module, defaulting to sandbox if no
+    environment variables exist. *)
+let or_default param =
+  match param with
+  | None -> (
+      match Unix.getenv "GEMINI_ENV" with
+      | Some env -> of_string env
+      | None -> (module Sandbox ()))
+  | Some param -> param

--- a/src/gemini/common.ml
+++ b/src/gemini/common.ml
@@ -1,0 +1,240 @@
+(** Shared modules across various Gemini api endpoints *)
+
+module Auth = Auth
+module Result = Json.Result
+
+module Int_number = struct
+  type t = (int64[@encoding `number]) [@@deriving sexp, yojson, equal, compare]
+
+  include (Csvfields.Csv.Atom (Int64) : Csvfields.Csv.Csvable with type t := t)
+end
+
+module Int_string = struct
+  type t = (int64[@encoding `string]) [@@deriving sexp, yojson, equal, compare]
+
+  include (Csvfields.Csv.Atom (Int64) : Csvfields.Csv.Csvable with type t := t)
+end
+
+module Decimal_number = struct
+  type t = (float[@encoding `number]) [@@deriving sexp, yojson, equal, compare]
+end
+
+module Decimal_string = struct
+  type t = string [@@deriving sexp, yojson, equal, compare]
+
+  include (Csvfields.Csv.Atom (String) : Csvfields.Csv.Csvable with type t := t)
+
+  let of_string t = t
+  let to_string t = t
+end
+
+module Client_order_id = struct
+  type t = string [@@deriving sexp, yojson, equal, compare]
+end
+
+(** Represents an order side. *)
+module Side = struct
+  module T = struct
+    type t = [ `Buy | `Sell ] [@@deriving sexp, enumerate, equal, compare]
+    (** The type of an order side - [`Buy] or [`Sell]. *)
+
+    let to_string = function `Buy -> "buy" | `Sell -> "sell"
+  end
+
+  include T
+  include (Json.Make (T) : Json.S with type t := t)
+end
+
+(** Represents an exchange type. Only gemini is currently supported *)
+module Exchange = struct
+  module T = struct
+    type t = [ `Gemini ] [@@deriving sexp, enumerate, equal, compare]
+    (** The exchange type - gemini only, currently. *)
+
+    let to_string `Gemini = "gemini"
+  end
+
+  include T
+  include (Json.Make (T) : Json.S with type t := t)
+end
+
+(** Represents all styles of timestamps possibly returned
+    by various gemini endpoints. *)
+module Timestamp = struct
+  module T0 = struct
+    type t = Time_float_unix.t [@@deriving sexp, equal, compare]
+    (** A timestamp is just a core time instance that
+        was converted from some raw json date. *)
+
+    let to_string t =
+      Time_float_unix.to_span_since_epoch t
+      |> Time_float_unix.Span.to_ms |> Float.to_string
+
+    let to_yojson t = to_string t |> fun s -> `String s
+
+    let of_yojson_with_span span_fn json =
+      (match json with
+      | `String s -> `Ok (Float.of_string s)
+      | `Int i -> `Ok (Float.of_int i)
+      | `Int64 i -> `Ok (Float.of_int64 i)
+      | #Yojson.Safe.t as json -> `Error json)
+      |> function
+      | `Error json ->
+          Result.Error
+            (sprintf "expected float as json but got %S"
+               (Yojson.Safe.pretty_to_string json))
+      | `Ok f ->
+          span_fn f |> Time_float_unix.of_span_since_epoch |> fun ok ->
+          Result.Ok ok
+
+    let of_yojson (ms : Yojson.Safe.t) =
+      of_yojson_with_span Time_float_unix.Span.of_ms ms
+
+    let of_string s =
+      of_yojson (`String s) |> function
+      | Result.Error e -> failwith e
+      | Result.Ok x -> x
+  end
+
+  module T = struct
+    include T0
+    include (Csvfields.Csv.Atom (T0) : Csvfields.Csv.Csvable with type t := t)
+  end
+
+  module Ms = struct
+    include T
+
+    let of_yojson = of_yojson
+    let to_yojson (ms : t) = to_yojson ms
+  end
+
+  module Sec = struct
+    include T
+
+    let of_yojson (sec : Yojson.Safe.t) =
+      of_yojson_with_span Time_float_unix.Span.of_sec sec
+
+    let to_yojson (sec : t) = to_yojson sec
+  end
+
+  include T
+end
+
+(** Represents currencies supported by Gemini. *)
+module Currency = struct
+  module T = struct
+    type t = [ `Eth | `Btc | `Usd | `Zec | `Bch | `Ltc | `Luna | `Xtz | `Ust ]
+    [@@deriving sexp, enumerate, equal, compare]
+    (** An enumerated set of all supported currencies supported
+        currently by Gemini.
+    *)
+
+    let to_string = function
+      | `Eth -> "eth"
+      | `Btc -> "btc"
+      | `Usd -> "usd"
+      | `Zec -> "zec"
+      | `Bch -> "bch"
+      | `Ltc -> "ltc"
+      | `Luna -> "luna"
+      | `Xtz -> "xtz"
+      | `Ust -> "ust"
+  end
+
+  include T
+  include (Json.Make (T) : Json.S with type t := t)
+end
+
+(** A symbol on the gemini exchange - Symbols are two currency
+    names appended together which can be thought as
+    "Buy the first one, Sell the second one". So [`Btcusd] implies
+    you are buying btc and sell usd, effectively exchanging your
+    currency from usd to btc in the process.
+*)
+module Symbol = struct
+  module T = struct
+    type t =
+      [ `Btcusd
+      | `Ethusd
+      | `Ethbtc
+      | `Zecusd
+      | `Zecbtc
+      | `Zeceth
+      | `Zecbch
+      | `Zecltc
+      | `Ltcusd
+      | `Ltcbtc
+      | `Ltceth
+      | `Ltcbch
+      | `Bchusd
+      | `Bchbtc
+      | `Bcheth
+      | `Lunausd
+      | `Xtzusd ]
+    [@@deriving sexp, enumerate, equal, compare]
+    (** The type of a symbol pair. See the [Symbol] module for details. *)
+
+    let to_string : [< t ] -> string = function
+      | `Btcusd -> "btcusd"
+      | `Bchusd -> "bchusd"
+      | `Bchbtc -> "bchbtc"
+      | `Bcheth -> "bcheth"
+      | `Ethusd -> "ethusd"
+      | `Ethbtc -> "ethbtc"
+      | `Zecusd -> "zecusd"
+      | `Zecbtc -> "zecbtc"
+      | `Zeceth -> "zeceth"
+      | `Zecbch -> "zecbch"
+      | `Zecltc -> "zecltc"
+      | `Ltcusd -> "ltcusd"
+      | `Ltcbtc -> "ltcbtc"
+      | `Ltceth -> "ltceth"
+      | `Ltcbch -> "ltcbch"
+      | `Lunausd -> "lunausd"
+      | `Xtzusd -> "xtzusd"
+
+    let to_currency_pair : [< t ] -> Currency.t * Currency.t = function
+      | `Btcusd -> (`Btc, `Usd)
+      | `Bchusd -> (`Bch, `Usd)
+      | `Bchbtc -> (`Bch, `Btc)
+      | `Bcheth -> (`Bch, `Eth)
+      | `Ethusd -> (`Eth, `Usd)
+      | `Ethbtc -> (`Eth, `Btc)
+      | `Zecusd -> (`Zec, `Usd)
+      | `Zecbtc -> (`Zec, `Btc)
+      | `Zeceth -> (`Zec, `Eth)
+      | `Zecbch -> (`Zec, `Bch)
+      | `Zecltc -> (`Zec, `Ltc)
+      | `Ltcusd -> (`Ltc, `Usd)
+      | `Ltcbtc -> (`Ltc, `Btc)
+      | `Ltceth -> (`Ltc, `Eth)
+      | `Ltcbch -> (`Ltc, `Bch)
+      | `Lunausd -> (`Luna, `Usd)
+      | `Xtzusd -> (`Xtz, `Usd)
+
+    let to_currency : [< t ] -> Side.t -> Currency.t =
+     fun t side ->
+      to_currency_pair t |> fun (buy, sell) ->
+      match side with `Buy -> buy | `Sell -> sell
+  end
+
+  include T
+  include (Json.Make (T) : Json.S with type t := t)
+end
+
+(** Represents order types supported on Gemini. *)
+module Order_type = struct
+  module T = struct
+    type t = [ `Exchange_limit ] [@@deriving sexp, enumerate, equal, compare]
+    (** The type of order types- only [`Exchange_limit] is
+        currently supported. *)
+
+    let to_string = function `Exchange_limit -> "exchange limit"
+  end
+
+  include T
+  include (Json.Make (T) : Json.S with type t := t)
+end
+
+(** The protocol version. *)
+let v1 = "v1"

--- a/src/gemini/csv_support.ml
+++ b/src/gemini/csv_support.ml
@@ -1,0 +1,119 @@
+(** Csv support, including generic optional and list types. *)
+
+module Optional = struct
+  module type ARGS = sig
+    type t [@@deriving sexp, yojson]
+
+    include Csvfields.Csv.Stringable with type t := t
+
+    val null : string
+  end
+
+  module Default_args (Args : sig
+    type t [@@deriving sexp, yojson]
+
+    include Csvfields.Csv.Stringable with type t := t
+  end) : ARGS with type t = Args.t = struct
+    let null = ""
+
+    include Args
+  end
+
+  module type S = sig
+    type elt [@@deriving sexp, yojson]
+    type t = elt option [@@deriving sexp, yojson]
+
+    include Csvfields.Csv.Csvable with type t := t
+  end
+
+  module Make (C : ARGS) : S with type elt = C.t = struct
+    type elt = C.t [@@deriving sexp, yojson]
+
+    module T = struct
+      type t = elt option [@@deriving sexp, yojson]
+
+      let to_string t = Option.value_map ~default:C.null t ~f:C.to_string
+
+      let of_string s =
+        if String.equal C.null s then None else Some (C.of_string s)
+    end
+
+    include T
+    include (Csvfields.Csv.Atom (T) : Csvfields.Csv.Csvable with type t := t)
+  end
+
+  module Make_default (Args : sig
+    type t [@@deriving sexp, yojson]
+
+    include Csvfields.Csv.Stringable with type t := t
+  end) =
+    Make (Default_args (Args))
+
+  module String = Make_default (struct
+    type t = string [@@deriving yojson]
+
+    include (String : module type of String with type t := t)
+  end)
+end
+
+module List = struct
+  module type ARGS = sig
+    type t [@@deriving sexp, yojson]
+
+    include Csvfields.Csv.Stringable with type t := t
+
+    val sep : char
+  end
+
+  module Default_args (Args : sig
+    type t [@@deriving sexp, yojson]
+
+    include Csvfields.Csv.Stringable with type t := t
+  end) =
+  struct
+    let sep = ' '
+
+    include Args
+  end
+
+  module type S = sig
+    type elt [@@deriving sexp, yojson]
+    type t = elt list [@@deriving sexp, yojson]
+
+    include Csvfields.Csv.Csvable with type t := t
+  end
+
+  module Make (C : ARGS) : S with type elt = C.t = struct
+    type elt = C.t [@@deriving sexp, yojson]
+
+    module T = struct
+      type t = elt list [@@deriving sexp, yojson]
+
+      let to_string t =
+        List.map ~f:C.to_string t |> String.concat ~sep:(Char.to_string C.sep)
+
+      let of_string s = String.split ~on:C.sep s |> List.map ~f:C.of_string
+    end
+
+    include T
+    include (Csvfields.Csv.Atom (T) : Csvfields.Csv.Csvable with type t := t)
+  end
+
+  module Make_default (Args : sig
+    type t [@@deriving sexp, yojson]
+
+    include Csvfields.Csv.Stringable with type t := t
+  end) =
+    Make (Default_args (Args))
+
+  module String = Make (Default_args (struct
+    type t = string [@@deriving yojson]
+
+    include (String : module type of String with type t := t)
+  end))
+end
+
+let write_header out header =
+  let s = sprintf "%s\n" (String.concat ~sep:"," header) in
+  Log.Global.debug "csv_support: writing header: %s" s;
+  Out_channel.output_string out s

--- a/src/gemini/dune
+++ b/src/gemini/dune
@@ -1,0 +1,26 @@
+(library
+  (name gemini)
+  (public_name gemini)
+  (flags
+    :standard -w -73
+    -open Core
+    -open Async
+  )
+  (preprocess (pps ppx_jane ppx_deriving_yojson ppx_csv_conv))
+  (synopsis "Gemini REST Client for OCaml")
+  (library_flags -linkall)
+  (libraries
+              async
+              cohttp-async
+              core_unix.command_unix
+              csvfields
+              ppx_deriving_yojson.runtime
+              ppx_csv_conv
+              uri
+              yojson
+              zarith
+              nocrypto
+              hex
+              websocket-async
+  )
+)

--- a/src/gemini/gemini.ml
+++ b/src/gemini/gemini.ml
@@ -1,0 +1,358 @@
+open Common
+module Auth = Auth
+module Cfg = Cfg
+module Nonce = Nonce
+module Rest = Rest
+module Result = Json.Result
+module Inf_pipe = Inf_pipe
+
+module V1 = struct
+  let path = [ "v1" ]
+
+  module Side = Side
+  module Exchange = Exchange
+  module Timestamp = Timestamp
+  module Market_data = Market_data
+  module Order_events = Order_events
+  module Currency = Currency
+  module Symbol = Symbol
+  module Order_type = Order_type
+
+  module Heartbeat = struct
+    module T = struct
+      let name = "heartbeat"
+      let path = path @ [ "heartbeat" ]
+
+      type request = unit [@@deriving sexp, yojson]
+
+      type response = { result : bool [@default true] }
+      [@@deriving sexp, of_yojson]
+    end
+
+    include T
+    include Rest.Make_no_arg (T)
+  end
+
+  module Order_execution_option = struct
+    module T = struct
+      type t = [ `Maker_or_cancel | `Immediate_or_cancel | `Auction_only ]
+      [@@deriving sexp, enumerate]
+
+      let to_string = function
+        | `Maker_or_cancel -> "maker_or_cancel"
+        | `Immediate_or_cancel -> "immediate_or_cancel"
+        | `Auction_only -> "auction_only"
+    end
+
+    include T
+    include (Json.Make (T) : Json.S with type t := t)
+  end
+
+  module Break_type = struct
+    module T = struct
+      type t = [ `Manual | `Full ]
+      [@@deriving sexp, enumerate, hash, equal, yojson]
+
+      let to_string = function `Manual -> "manual" | `Full -> "full"
+    end
+
+    include T
+    include (Json.Make (T) : Json.S with type t := t)
+  end
+
+  module Trade = struct
+    type t = {
+      price : Decimal_string.t;
+      amount : Decimal_string.t;
+      timestamp : Timestamp.Sec.t;
+      timestampms : Timestamp.Ms.t;
+      type_ : Side.t; [@key "type"]
+      aggressor : bool;
+      fee_currency : Currency.t;
+      fee_amount : Decimal_string.t;
+      tid : Int_number.t;
+      order_id : Int_string.t;
+      client_order_id : Client_order_id.t option; [@default None]
+      is_auction_fill : bool;
+      is_clearing_fill : bool;
+      symbol : Symbol.t;
+      exchange : Exchange.t;
+      break : Break_type.t option; [@default None]
+    }
+    [@@deriving yojson, sexp]
+  end
+
+  module Order = struct
+    let name = "order"
+    let path = path @ [ "order" ]
+
+    module Status = struct
+      module T = struct
+        let name = "status"
+        let path = path @ [ "status" ]
+
+        type request = { order_id : Int_number.t } [@@deriving yojson, sexp]
+
+        type response = {
+          client_order_id : Client_order_id.t option; [@default None]
+          order_id : Int_string.t;
+          id : Int_string.t;
+          symbol : Symbol.t;
+          exchange : Exchange.t;
+          avg_execution_price : Decimal_string.t;
+          side : Side.t;
+          type_ : Order_type.t; [@key "type"]
+          timestamp : Timestamp.Sec.t;
+          timestampms : Timestamp.Ms.t;
+          is_live : bool;
+          is_cancelled : bool;
+          is_hidden : bool;
+          was_forced : bool;
+          executed_amount : Decimal_string.t;
+          remaining_amount : Decimal_string.t;
+          options : Order_execution_option.t list;
+          price : Decimal_string.t;
+          original_amount : Decimal_string.t;
+          trades : Trade.t list; [@default []]
+        }
+        [@@deriving yojson, sexp]
+      end
+
+      include T
+      include Rest.Make (T)
+    end
+
+    module New = struct
+      module T = struct
+        let name = "new"
+        let path = path @ [ "new" ]
+
+        type request = {
+          client_order_id : Client_order_id.t;
+          symbol : Symbol.t;
+          amount : Decimal_string.t;
+          price : Decimal_string.t;
+          side : Side.t;
+          type_ : Order_type.t; [@key "type"]
+          options : Order_execution_option.t list;
+        }
+        [@@deriving sexp, yojson]
+
+        type response = Status.response [@@deriving of_yojson, sexp]
+      end
+
+      include T
+      include Rest.Make (T)
+    end
+
+    module Cancel = struct
+      let name = "cancel"
+      let path = path @ [ "cancel" ]
+
+      module By_order_id = struct
+        module T = struct
+          let name = "by-order-id"
+          let path = path
+
+          type request = { order_id : Int_string.t } [@@deriving sexp, yojson]
+          type response = Status.response [@@deriving sexp, of_yojson]
+        end
+
+        include T
+        include Rest.Make (T)
+      end
+
+      type details = {
+        cancelled_orders : Status.response list; [@key "cancelledOrders"]
+        cancel_rejects : Status.response list; [@key "cancelRejects"]
+      }
+      [@@deriving sexp, yojson]
+
+      module All = struct
+        module T = struct
+          let name = "all"
+          let path = path @ [ "all" ]
+
+          type request = unit [@@deriving sexp, yojson]
+          type response = { details : details } [@@deriving sexp, of_yojson]
+        end
+
+        include T
+        include Rest.Make_no_arg (T)
+      end
+
+      module Session = struct
+        module T = struct
+          let name = "session"
+          let path = path @ [ "session" ]
+
+          type request = unit [@@deriving sexp, yojson]
+          type response = { details : details } [@@deriving sexp, of_yojson]
+        end
+
+        include T
+        include Rest.Make_no_arg (T)
+      end
+
+      let command : string * Command.t =
+        ( name,
+          Command.group
+            ~summary:(Path.to_summary ~has_subnames:true path)
+            [ By_order_id.command; Session.command; All.command ] )
+    end
+
+    let command : string * Command.t =
+      ( name,
+        Command.group
+          ~summary:(Path.to_summary ~has_subnames:true path)
+          [ New.command; Cancel.command; Status.command ] )
+  end
+
+  module Orders = struct
+    module T = struct
+      let name = "orders"
+      let path = path @ [ "orders" ]
+
+      type request = unit [@@deriving sexp, yojson]
+      type response = Order.Status.response list [@@deriving of_yojson, sexp]
+    end
+
+    include T
+    include Rest.Make_no_arg (T)
+  end
+
+  module Mytrades = struct
+    module T = struct
+      let name = "mytrades"
+      let path = path @ [ "mytrades" ]
+
+      type request = {
+        symbol : Symbol.t;
+        limit_trades : int option; [@default None]
+        timestamp : Timestamp.Sec.t option; [@default None]
+      }
+      [@@deriving sexp, yojson]
+
+      type response = Trade.t list [@@deriving of_yojson, sexp]
+    end
+
+    include T
+    include Rest.Make (T)
+  end
+
+  module Tradevolume = struct
+    type volume = {
+      account_id : (Int_number.t option[@default None]);
+      symbol : Symbol.t;
+      base_currency : Currency.t;
+      notional_currency : Currency.t;
+      data_date : string;
+          (*TODO use timestamp or a date module with MMMM-DD-YY *)
+      total_volume_base : Decimal_number.t;
+      maker_buy_sell_ratio : Decimal_number.t;
+      buy_maker_base : Decimal_number.t;
+      buy_maker_notional : Decimal_number.t;
+      buy_maker_count : Int_number.t;
+      sell_maker_base : Decimal_number.t;
+      sell_maker_notional : Decimal_number.t;
+      sell_maker_count : Int_number.t;
+      buy_taker_base : Decimal_number.t;
+      buy_taker_notional : Decimal_number.t;
+      buy_taker_count : Int_number.t;
+      sell_taker_base : Decimal_number.t;
+      sell_taker_notional : Decimal_number.t;
+      sell_taker_count : Int_number.t;
+    }
+    [@@deriving yojson, sexp]
+
+    module T = struct
+      let name = "tradevolume"
+      let path = path @ [ "tradevolume" ]
+
+      type request = unit [@@deriving yojson, sexp]
+      type response = volume list list [@@deriving of_yojson, sexp]
+    end
+
+    include T
+    include Rest.Make_no_arg (T)
+  end
+
+  module Balances = struct
+    module T = struct
+      let name = "balances"
+      let path = path @ [ "balances" ]
+
+      type request = unit [@@deriving yojson, sexp]
+
+      type balance = {
+        currency : Currency.t;
+        amount : Decimal_string.t;
+        available : Decimal_string.t;
+        available_for_withdrawal : Decimal_string.t;
+            [@key "availableForWithdrawal"]
+        type_ : string; [@key "type"]
+      }
+      [@@deriving yojson, sexp]
+
+      type response = balance list [@@deriving of_yojson, sexp]
+    end
+
+    include T
+    include Rest.Make_no_arg (T)
+  end
+
+  module Notional_volume = struct
+    module T = struct
+      let name = "notionalvolume"
+      let path = path @ [ "notionalvolume" ]
+
+      type request = {
+        symbol : Symbol.t option; [@default None]
+        account : string option; [@default None]
+      }
+      [@@deriving yojson, sexp]
+
+      type notional_1d_volume = {
+        date : string; (* TODO use strict date type *)
+        notional_volume : Decimal_number.t;
+      }
+      [@@deriving sexp, yojson]
+
+      type response = {
+        last_updated_ms : Timestamp.Ms.t;
+        web_maker_fee_bps : Int_number.t;
+        web_taker_fee_bps : Int_number.t;
+        web_auction_fee_bps : Int_number.t;
+        api_maker_fee_bps : Int_number.t;
+        api_taker_fee_bps : Int_number.t;
+        api_auction_fee_bps : Int_number.t;
+        fix_maker_fee_bps : Int_number.t;
+        fix_taker_fee_bps : Int_number.t;
+        fix_auction_fee_bps : Int_number.t;
+        block_maker_fee_bps : Int_number.t;
+        block_taker_fee_bps : Int_number.t;
+        date : string; (* TODO use strict date type *)
+        notional_30d_volume : Decimal_number.t;
+        notional_1d_volume : notional_1d_volume list;
+      }
+      [@@deriving yojson, sexp]
+    end
+
+    include T
+    include Rest.Make (T)
+  end
+
+  let command : Command.t =
+    Command.group ~summary:"Gemini Command System"
+      [
+        Heartbeat.command;
+        Order.command;
+        Orders.command;
+        Mytrades.command;
+        Tradevolume.command;
+        Balances.command;
+        Market_data.command;
+        Order_events.command;
+        Notional_volume.command;
+      ]
+end

--- a/src/gemini/gemini.mli
+++ b/src/gemini/gemini.mli
@@ -1,0 +1,421 @@
+(** A strongly typed gemini trading api written in pure OCaml
+    with both websocket and rest endpoints supported.
+
+    Submodules of the [V1] module are either REST operations which
+    can be invoked via a well typed invocation of [Operation.post],
+    or they are web socket interfaces such as [Market_data] and
+    [Order_events]. Use the [client] function to get a typed response pipe over
+    the socket of these services.
+
+    All service invocations require a [Cfg] module which is usually
+    provided from the command line or environment variables for api host and
+    secret information.
+*)
+
+open Common
+module Auth = Auth
+module Cfg = Cfg
+module Nonce = Nonce
+module Rest = Rest
+module Result = Json.Result
+module Inf_pipe = Inf_pipe
+
+(** Version v1 of the Gemini REST and web socket apis. *)
+module V1 : sig
+  val path : string list
+
+  (** Heartbeat REST api operation. *)
+  module Heartbeat : sig
+    type request = unit [@@deriving sexp, of_yojson]
+    type response = { result : bool } [@@deriving sexp]
+
+    include
+      Rest.Operation.S
+        with type request := request
+        with type response := response
+
+    val post :
+      (module Cfg.S) ->
+      Nonce.reader ->
+      request ->
+      [ Rest.Error.post | `Ok of response ] Deferred.t
+  end
+
+  module Timestamp : module type of Timestamp
+  module Currency : module type of Currency
+  module Symbol : module type of Symbol
+  module Exchange : module type of Exchange
+  module Side : module type of Side
+  module Order_type : module type of Order_type
+
+  (** Represents different execution rules for an order. *)
+  module Order_execution_option : sig
+    type t = [ `Auction_only | `Immediate_or_cancel | `Maker_or_cancel ]
+    [@@deriving sexp]
+    (** The type of an order execution rule. *)
+
+    include Json.S with type t := t
+  end
+
+  (** Represents different break types when trades are busted. *)
+  module Break_type : sig
+    type t = [ `Manual | `Full ] [@@deriving sexp, enumerate, hash, equal]
+
+    include Json.S with type t := t
+  end
+
+  (** Represents a single trade. *)
+  module Trade : sig
+    type t = {
+      price : Decimal_string.t;
+      amount : Decimal_string.t;
+      timestamp : Timestamp.Sec.t;
+      timestampms : Timestamp.Ms.t;
+      type_ : Side.t; [@key "type"]
+      aggressor : bool;
+      fee_currency : Currency.t;
+      fee_amount : Decimal_string.t;
+      tid : Int_number.t;
+      order_id : Int_string.t;
+      client_order_id : Client_order_id.t option; [@default None]
+      is_auction_fill : bool;
+      is_clearing_fill : bool;
+      symbol : Symbol.t;
+      exchange : Exchange.t;
+      break : Break_type.t option; [@default None]
+    }
+    [@@deriving of_yojson, sexp]
+  end
+
+  (** Represents an order on the Gemini trading exchange over
+      the REST api. *)
+  module Order : sig
+    val name : string
+    val path : string list
+
+    (** Represents the status of an order on the Gemini trading
+          exchange over the REST api. *)
+    module Status : sig
+      type request = { order_id : Int_number.t } [@@deriving sexp, of_yojson]
+
+      type response = {
+        client_order_id : Client_order_id.t option;
+        order_id : Int_string.t;
+        id : Int_string.t;
+        symbol : Symbol.t;
+        exchange : Exchange.t;
+        avg_execution_price : Decimal_string.t;
+        side : Side.t;
+        type_ : Order_type.t;
+        timestamp : Timestamp.Sec.t;
+        timestampms : Timestamp.Ms.t;
+        is_live : bool;
+        is_cancelled : bool;
+        is_hidden : bool;
+        was_forced : bool;
+        executed_amount : Decimal_string.t;
+        remaining_amount : Decimal_string.t;
+        options : Order_execution_option.t list;
+        price : Decimal_string.t;
+        original_amount : Decimal_string.t;
+        trades : Trade.t list;
+      }
+      [@@deriving sexp]
+
+      include
+        Rest.Operation.S
+          with type request := request
+          with type response := response
+
+      val post :
+        (module Cfg.S) ->
+        Nonce.reader ->
+        request ->
+        [ Rest.Error.post | `Ok of response ] Deferred.t
+
+      val command : string * Command.t
+    end
+
+    (** Represents a new order request on the Gemini trading exchange
+          over the REST api. *)
+    module New : sig
+      type request = {
+        client_order_id : Client_order_id.t;
+        symbol : Symbol.t;
+        amount : Decimal_string.t;
+        price : Decimal_string.t;
+        side : Side.t;
+        type_ : Order_type.t;
+        options : Order_execution_option.t list;
+      }
+      [@@deriving sexp, of_yojson]
+
+      type response = Status.response [@@deriving sexp]
+
+      include
+        Rest.Operation.S
+          with type request := request
+          with type response := response
+
+      val post :
+        (module Cfg.S) ->
+        Nonce.reader ->
+        request ->
+        [ Rest.Error.post | `Ok of response ] Deferred.t
+
+      val command : string * Command.t
+    end
+
+    (** Represents order cancellation features on the
+          Gemini trading exchange over the REST api. *)
+    module Cancel : sig
+      val name : string
+      val path : string list
+
+      module By_order_id : sig
+        type request = { order_id : Int_string.t } [@@deriving sexp, of_yojson]
+        type response = Status.response [@@deriving sexp]
+
+        include
+          Rest.Operation.S
+            with type request := request
+            with type response := response
+
+        val post :
+          (module Cfg.S) ->
+          Nonce.reader ->
+          request ->
+          [ Rest.Error.post | `Ok of response ] Deferred.t
+
+        val command : string * Command.t
+      end
+
+      type details = {
+        cancelled_orders : Status.response list;
+        cancel_rejects : Status.response list;
+      }
+      [@@deriving sexp, yojson]
+
+      module All : sig
+        type request = unit [@@deriving sexp, of_yojson]
+        type response = { details : details } [@@deriving sexp]
+
+        include
+          Rest.Operation.S
+            with type request := request
+            with type response := response
+
+        val post :
+          (module Cfg.S) ->
+          Nonce.reader ->
+          request ->
+          [ Rest.Error.post | `Ok of response ] Deferred.t
+
+        val command : string * Command.t
+      end
+
+      module Session : sig
+        type request = unit [@@deriving sexp, of_yojson]
+        type response = { details : details } [@@deriving sexp]
+
+        include
+          Rest.Operation.S
+            with type request := request
+            with type response := response
+
+        val post :
+          (module Cfg.S) ->
+          Nonce.reader ->
+          request ->
+          [ Rest.Error.post | `Ok of response ] Deferred.t
+
+        val command : string * Command.t
+      end
+
+      val command : string * Command.t
+    end
+
+    val command : string * Command.t
+  end
+
+  (** Gets the status of all open orders on
+       Gemini trading exchange over the REST api. *)
+  module Orders : sig
+    type request = unit [@@deriving sexp, of_yojson]
+    type response = Order.Status.response list [@@deriving sexp]
+
+    include
+      Rest.Operation.S
+        with type request := request
+        with type response := response
+
+    val post :
+      (module Cfg.S) ->
+      Nonce.reader ->
+      request ->
+      [ Rest.Error.post | `Ok of response ] Deferred.t
+
+    val command : string * Command.t
+  end
+
+  (** Gets all trades executed by this api user on
+       Gemini trading exchange over the REST api. *)
+  module Mytrades : sig
+    type request = {
+      symbol : Symbol.t;
+      limit_trades : int option;
+      timestamp : Timestamp.Sec.t option;
+    }
+    [@@deriving sexp, of_yojson]
+    (** Trade request parameters. *)
+
+    type response = Trade.t list [@@deriving sexp]
+    (** Mytrades repsonse type- the type of a list trades. *)
+
+    include
+      Rest.Operation.S
+        with type request := request
+        with type response := response
+
+    val post :
+      (module Cfg.S) ->
+      Nonce.reader ->
+      request ->
+      [ Rest.Error.post | `Ok of response ] Deferred.t
+
+    val command : string * Command.t
+  end
+
+  (** Gets all trade volume executed by on the
+      Gemini trading exchange over the REST api. *)
+  module Tradevolume : sig
+    type volume = {
+      account_id : Int_number.t option;
+      symbol : Symbol.t;
+      base_currency : Currency.t;
+      notional_currency : Currency.t;
+      data_date : string;
+      total_volume_base : Decimal_number.t;
+      maker_buy_sell_ratio : Decimal_number.t;
+      buy_maker_base : Decimal_number.t;
+      buy_maker_notional : Decimal_number.t;
+      buy_maker_count : Int_number.t;
+      sell_maker_base : Decimal_number.t;
+      sell_maker_notional : Decimal_number.t;
+      sell_maker_count : Int_number.t;
+      buy_taker_base : Decimal_number.t;
+      buy_taker_notional : Decimal_number.t;
+      buy_taker_count : Int_number.t;
+      sell_taker_base : Decimal_number.t;
+      sell_taker_notional : Decimal_number.t;
+      sell_taker_count : Int_number.t;
+    }
+    [@@deriving sexp, yojson]
+    (** The type of a trade volume entity for
+          one particular symbol on the Gemini trading exchange.
+      *)
+
+    type request = unit [@@deriving sexp, of_yojson]
+
+    type response = volume list list [@@deriving sexp]
+    (** The type of a trade volume response, which is a list of list
+          of volumes grouped by exchange symbol. *)
+
+    include
+      Rest.Operation.S
+        with type request := request
+        with type response := response
+
+    val post :
+      (module Cfg.S) ->
+      Nonce.reader ->
+      request ->
+      [ Rest.Error.post | `Ok of response ] Deferred.t
+
+    val command : string * Command.t
+  end
+
+  (** Gets all balances for this api user on the
+       Gemini trading exchange over the REST api. *)
+  module Balances : sig
+    type request = unit [@@deriving sexp, of_yojson]
+    (** Balance queries have no request parameters. *)
+
+    type balance = {
+      currency : Currency.t;
+      amount : Decimal_string.t;
+      available : Decimal_string.t;
+      available_for_withdrawal : Decimal_string.t;
+      type_ : string;
+    }
+    [@@deriving sexp, yojson]
+    (** The type of a balance for one specific currency. *)
+
+    (* A list of balances, one for each supported currency. *)
+    type response = balance list [@@deriving sexp]
+
+    include
+      Rest.Operation.S
+        with type request := request
+        with type response := response
+
+    val post :
+      (module Cfg.S) ->
+      Nonce.reader ->
+      request ->
+      [ Rest.Error.post | `Ok of response ] Deferred.t
+
+    val command : string * Command.t
+  end
+
+  module Notional_volume : sig
+    type request = {
+      symbol : Symbol.t option; [@default None]
+      account : string option; [@default None]
+    }
+    [@@deriving of_yojson, sexp]
+
+    type notional_1d_volume = {
+      date : string; (* TODO use strict date type *)
+      notional_volume : Decimal_number.t;
+    }
+    [@@deriving sexp, yojson]
+
+    type response = {
+      last_updated_ms : Timestamp.Ms.t;
+      web_maker_fee_bps : Int_number.t;
+      web_taker_fee_bps : Int_number.t;
+      web_auction_fee_bps : Int_number.t;
+      api_maker_fee_bps : Int_number.t;
+      api_taker_fee_bps : Int_number.t;
+      api_auction_fee_bps : Int_number.t;
+      fix_maker_fee_bps : Int_number.t;
+      fix_taker_fee_bps : Int_number.t;
+      fix_auction_fee_bps : Int_number.t;
+      block_maker_fee_bps : Int_number.t;
+      block_taker_fee_bps : Int_number.t;
+      date : string; (* TODO use strict date type *)
+      notional_30d_volume : Decimal_number.t;
+      notional_1d_volume : notional_1d_volume list;
+    }
+    [@@deriving sexp]
+
+    include
+      Rest.Operation.S
+        with type request := request
+        with type response := response
+
+    val post :
+      (module Cfg.S) ->
+      Nonce.reader ->
+      request ->
+      [ Rest.Error.post | `Ok of response ] Deferred.t
+
+    val command : string * Command.t
+  end
+
+  module Market_data = Market_data
+  module Order_events = Order_events
+
+  val command : Command.t
+end

--- a/src/gemini/inf_pipe.ml
+++ b/src/gemini/inf_pipe.ml
@@ -1,0 +1,109 @@
+open Async
+
+module T = struct
+  module Reader = struct
+    type 'a t = 'a Pipe.Reader.t
+
+    let create (reader : 'a Pipe.Reader.t) : 'a t = reader
+  end
+
+  module Writer = struct
+    type 'a t = 'a Pipe.Writer.t
+
+    let create (writer : 'a Pipe.Writer.t) : 'a t = writer
+  end
+
+  let create = Pipe.create
+
+  let read ?consumer t =
+    Pipe.read ?consumer t >>| function `Ok x -> x | `Eof -> assert false
+
+  let read_now ?consumer t =
+    Pipe.read_now ?consumer t |> function
+    | `Ok _ as ok -> ok
+    | `Nothing_available as na -> na
+    | `Eof -> assert false
+
+  let read_exactly ?consumer t ~num_values =
+    Pipe.read_exactly ?consumer t ~num_values >>| function
+    | `Exactly e -> e
+    | `Fewer _ | `Eof -> assert false
+
+  let to_pipe t : 'a Pipe.Reader.t = t
+  let interleave l = Pipe.interleave l |> Reader.create
+
+  let unfold ~init ~f : 'a Reader.t =
+    Pipe.unfold ~init ~f:(fun (acc : 's) ->
+        f acc >>| fun (acc, s) -> Some (acc, s))
+
+  let map = Pipe.map
+  let filter_map = Pipe.filter_map
+  let folding_map = Pipe.folding_map
+  let folding_filter_map = Pipe.folding_filter_map
+  let folding_filter_map' = Pipe.folding_filter_map'
+  let transfer = Pipe.transfer
+end
+
+module type S = sig
+  module Reader : sig
+    type 'a t = private 'a Pipe.Reader.t
+
+    val create : 'a Pipe.Reader.t -> 'a t
+  end
+
+  module Writer : sig
+    type 'a t = private 'a Pipe.Writer.t
+
+    val create : 'a Pipe.Writer.t -> 'a t
+  end
+
+  val create :
+    ?size_budget:int -> ?info:Sexp.t -> unit -> 'a Reader.t * 'a Writer.t
+
+  val read : ?consumer:Pipe.Consumer.t -> 'a Reader.t -> 'a Deferred.t
+
+  val read_now :
+    ?consumer:Pipe.Consumer.t ->
+    'a Reader.t ->
+    [> `Nothing_available | `Ok of 'a ]
+
+  val read_exactly :
+    ?consumer:Pipe.Consumer.t ->
+    'a Reader.t ->
+    num_values:int ->
+    'a Base.Queue.t Deferred.t
+
+  val unfold : init:'s -> f:('s -> ('a * 's) Deferred.t) -> 'a Reader.t
+  val map : 'a Reader.t -> f:('a -> 'b) -> 'b Reader.t
+
+  val filter_map :
+    ?max_queue_length:int -> 'a Reader.t -> f:('a -> 'b option) -> 'b Reader.t
+
+  val interleave : 'a Reader.t list -> 'a Reader.t
+  val to_pipe : 'a Reader.t -> 'a Pipe.Reader.t
+
+  val folding_map :
+    ?max_queue_length:int ->
+    'a Reader.t ->
+    init:'accum ->
+    f:('accum -> 'a -> 'accum * 'c) ->
+    'c Reader.t
+
+  val folding_filter_map :
+    ?max_queue_length:int ->
+    'a Reader.t ->
+    init:'accum ->
+    f:('accum -> 'a -> 'accum * 'c option) ->
+    'c Reader.t
+
+  val folding_filter_map' :
+    ?max_queue_length:int ->
+    'a Reader.t ->
+    init:'accum ->
+    f:('accum -> 'a -> ('accum * 'c option) Deferred.t) ->
+    'c Reader.t
+
+  val transfer : 'a Reader.t -> 'b Writer.t -> f:('a -> 'b) -> unit Deferred.t
+end
+
+include (T : S)

--- a/src/gemini/json.ml
+++ b/src/gemini/json.ml
@@ -1,0 +1,98 @@
+(** Json utility functions. *)
+
+(** Result specification when deserializing raw
+    json into something strongly in typed ocaml.
+  *)
+module Result = struct
+  include Result
+
+  (** Unify results into tuple [('a , 'b)] if both are ok,
+      otherwise produce one of the errors .
+  *)
+  let both x y : ('a * 'b, 'error) t =
+    match x with
+    | Result.Ok x -> (
+        match y with
+        | Result.Ok y -> Result.Ok (x, y)
+        | Result.Error _ as e -> e)
+    | Result.Error _ as e -> e
+end
+
+module type S = sig
+  type t [@@deriving yojson, enumerate]
+
+  val dict : (string * t) list
+  val of_string_opt : string -> t option
+  val error_message : string -> string
+  val of_string : string -> t
+  val to_string : t -> string
+  val is_csv_atom : bool
+  val rev_csv_header' : string list -> 'a -> 'b -> string list
+
+  val rev_csv_header_spec' :
+    Csvfields.Csv.Spec.t list -> 'a -> 'b -> Csvfields.Csv.Spec.t list
+
+  val t_of_row' : 'a -> string list -> (unit -> t) * string list
+
+  val write_row_of_t' :
+    is_first:bool ->
+    is_last:bool ->
+    writer:(string -> unit) ->
+    'a ->
+    'b ->
+    t ->
+    unit
+
+  val csv_header : string list
+  val csv_header_spec : Csvfields.Csv.Spec.t list
+  val t_of_row : string list -> t
+  val row_of_t : t -> string list
+  val csv_load : ?separator:char -> string -> t list
+  val csv_load_in : ?separator:char -> In_channel.t -> t list
+  val csv_save_fn : ?separator:char -> (string -> unit) -> t list -> unit
+  val csv_save_out : ?separator:char -> Out_channel.t -> t list -> unit
+  val csv_save : ?separator:char -> string -> t list -> unit
+end
+
+(** An enumeration encodable as a json string. *)
+module type ENUM_STRING = sig
+  type t [@@deriving enumerate]
+
+  val to_string : t -> string
+end
+
+(** Produce json encoders and decoders given an enumerated
+    type and its string representations. *)
+module Make (E : ENUM_STRING) : S with type t = E.t = struct
+  module T = struct
+    let dict = List.zip_exn (List.map E.all ~f:E.to_string) E.all
+
+    let of_string_opt (s : string) : E.t option =
+      List.Assoc.find dict s ~equal:(fun s s' ->
+          String.equal (String.lowercase s) (String.lowercase s'))
+
+    let error_message x =
+      sprintf "String %S is not a valid enumeration value. Expected one of %s" x
+        (String.concat ~sep:", " (List.map ~f:fst dict))
+
+    let of_string x =
+      of_string_opt x |> Option.value_exn ~message:(error_message x)
+
+    let to_yojson t = `String (E.to_string t)
+
+    let of_yojson (json : Yojson.Safe.t) =
+      match json with
+      | `String s -> (
+          match of_string_opt s with
+          | Some t -> Result.return t
+          | None -> error_message s |> Result.fail)
+      | #Yojson.Safe.t ->
+          Result.failf "expected json string but got %S"
+            (Yojson.Safe.to_string json)
+
+    include E
+  end
+
+  include T
+  include (Csvfields.Csv.Atom (T) : Csvfields.Csv.Csvable with type t := t)
+end

--- a/src/gemini/market_data.ml
+++ b/src/gemini/market_data.ml
@@ -1,0 +1,446 @@
+open Common
+
+module Side = struct
+  module Bid_ask = struct
+    module T = struct
+      type t = [ `Bid | `Ask ] [@@deriving sexp, enumerate]
+
+      let to_string : [< t ] -> string = function
+        | `Bid -> "bid"
+        | `Ask -> "ask"
+    end
+
+    include T
+    include (Json.Make (T) : Json.S with type t := t)
+  end
+
+  module Auction = struct
+    module T = struct
+      type t = [ `Auction ] [@@deriving sexp, enumerate]
+
+      let to_string = function `Auction -> "auction"
+    end
+
+    include T
+    include (Json.Make (T) : Json.S with type t := t)
+  end
+
+  module T = struct
+    type t = [ Bid_ask.t | Auction.t ] [@@deriving sexp, enumerate]
+
+    let to_string : [< t ] -> string = function
+      | #Bid_ask.t as bid_ask -> Bid_ask.to_string bid_ask
+      | #Auction.t as auction -> Auction.to_string auction
+  end
+
+  include T
+  include (Json.Make (T) : Json.S with type t := t)
+end
+
+module T = struct
+  let name = "marketdata"
+  let version = "v1"
+  let path = v1 :: [ "marketdata" ]
+
+  type uri_args = Symbol.t [@@deriving sexp, yojson, enumerate]
+
+  let authentication = `Public
+  let default_uri_args = Some `Ethusd
+  let encode_uri_args = Symbol.to_string
+
+  type query = unit [@@deriving sexp]
+
+  let encode_query _ = failwith "queries not supported"
+
+  module Message_type = struct
+    module T = struct
+      type t = [ `Update | `Heartbeat ] [@@deriving sexp, enumerate]
+
+      let to_string = function `Update -> "update" | `Heartbeat -> "heartbeat"
+    end
+
+    include T
+    include (Json.Make (T) : Json.S with type t := t)
+  end
+
+  module Event_type = struct
+    module T = struct
+      type t = [ `Trade | `Change | `Auction | `Auction_open | `Block_trade ]
+      [@@deriving sexp, enumerate, compare]
+
+      let to_string = function
+        | `Trade -> "trade"
+        | `Change -> "change"
+        | `Auction -> "auction"
+        | `Auction_open -> "auction_open"
+        | `Block_trade -> "block_trade"
+    end
+
+    include T
+    include Comparable.Make (T)
+    include (Json.Make (T) : Json.S with type t := t)
+  end
+
+  type heartbeat = unit [@@deriving sexp, of_yojson]
+
+  (*
+  let _with_common_headers (type t) ~event_id ~timestamp
+      (module T : Csvfields.Csv.Csvable with type t = t) =
+    let module TT = struct
+      include T
+      let csv_header = ["event_id";"timestamp"]@csv_header
+      let row_of_t t =
+        [
+          (Int64.to_string event_id);
+          (Timestamp.to_string timestamp)
+        ] @ (row_of_t t)
+
+      let csv_header_spec =
+        [(Leaf "event_id" : Csvfields.Csv.Spec.t);Leaf "timestamp"] @ csv_header_spec
+
+    end in
+    (module TT : Csvfields.Csv.Csvable with type t = t)
+*)
+
+  module Reason = struct
+    module T = struct
+      type t = [ `Place | `Trade | `Cancel | `Initial ]
+      [@@deriving sexp, enumerate]
+
+      let to_string = function
+        | `Place -> "place"
+        | `Trade -> "trade"
+        | `Cancel -> "cancel"
+        | `Initial -> "initial"
+    end
+
+    include T
+    include (Json.Make (T) : Json.S with type t := t)
+  end
+
+  module Change_event = struct
+    module T = struct
+      type t = {
+        price : Decimal_string.t;
+        side : Side.Bid_ask.t;
+        reason : Reason.t;
+        remaining : Decimal_string.t;
+        delta : Decimal_string.t;
+      }
+      [@@deriving sexp, of_yojson, fields, csv]
+    end
+
+    module Decorated = struct
+      type t = {
+        event_id : Int_number.t;
+        timestamp : Timestamp.t;
+        price : Decimal_string.t;
+        side : Side.Bid_ask.t;
+        reason : Reason.t;
+        remaining : Decimal_string.t;
+        delta : Decimal_string.t;
+      }
+      [@@deriving sexp, of_yojson, fields, csv]
+
+      let create ~event_id ~timestamp
+          ({ reason; side; price; remaining; delta } : T.t) =
+        { event_id; timestamp; side; reason; remaining; price; delta }
+    end
+
+    let to_decorated = Decorated.create
+
+    include T
+  end
+
+  module Trade_event = struct
+    module T = struct
+      type t = {
+        tid : Int_number.t;
+        price : Decimal_string.t;
+        amount : Decimal_string.t;
+        maker_side : Side.t; [@key "makerSide"]
+      }
+      [@@deriving of_yojson, sexp, fields, csv]
+    end
+
+    module Decorated = struct
+      type t = {
+        timestamp : Timestamp.t;
+        tid : Int_number.t;
+        price : Decimal_string.t;
+        amount : Decimal_string.t;
+        maker_side : Side.t; [@key "makerSide"]
+      }
+      [@@deriving of_yojson, sexp, fields, csv]
+
+      let create ~event_id ~timestamp ({ tid; price; amount; maker_side } : T.t)
+          =
+        match Int64.equal event_id tid with
+        | true -> { timestamp; tid; price; amount; maker_side }
+        | false ->
+            failwith
+              "logical error: event_id and trade id (tid) should be equal"
+    end
+
+    let to_decorated = Decorated.create
+
+    include T
+  end
+
+  module Block_trade_event = struct
+    module T = struct
+      type t = { price : Decimal_string.t; amount : Decimal_string.t }
+      [@@deriving of_yojson, sexp, fields, csv]
+    end
+
+    module Decorated = struct
+      type t = {
+        event_id : Int_number.t;
+        timestamp : Timestamp.t;
+        price : Decimal_string.t;
+        amount : Decimal_string.t;
+      }
+      [@@deriving of_yojson, sexp, fields, csv]
+
+      let create ~event_id ~timestamp ({ price; amount } : T.t) =
+        { event_id; timestamp; price; amount }
+    end
+
+    let to_decorated = Decorated.create
+
+    include T
+  end
+
+  module Auction_open_event = struct
+    type t = {
+      auction_open_ms : Timestamp.Ms.t;
+      auction_time_ms : Timestamp.Ms.t;
+      first_indicative_ms : Timestamp.Ms.t;
+      last_cancel_time_ms : Timestamp.Ms.t;
+    }
+    [@@deriving sexp, of_yojson, fields, csv]
+  end
+
+  module Auction_result = struct
+    module T = struct
+      type t = [ `Success | `Failure ] [@@deriving sexp, enumerate]
+
+      let to_string = function `Success -> "success" | `Failure -> "failure"
+    end
+
+    include T
+    include (Json.Make (T) : Json.S with type t := t)
+  end
+
+  module Auction_indicative_price_event = struct
+    type t = {
+      eid : Int_number.t;
+      result : Auction_result.t;
+      time_ms : Timestamp.Ms.t;
+      highest_bid_price : Decimal_string.t;
+      lowest_ask_price : Decimal_string.t;
+      collar_price : Decimal_string.t;
+      indicative_price : Decimal_string.t;
+      indicative_quantity : Decimal_string.t;
+    }
+    [@@deriving sexp, of_yojson, fields, csv]
+  end
+
+  module Auction_outcome_event = struct
+    type t = {
+      eid : Int_number.t;
+      result : Auction_result.t;
+      time_ms : Timestamp.Ms.t;
+      highest_bid_price : Decimal_string.t;
+      lowest_ask_price : Decimal_string.t;
+      collar_price : Decimal_string.t;
+      auction_price : Decimal_string.t;
+      auction_quantity : Decimal_string.t;
+    }
+    [@@deriving sexp, of_yojson, fields, csv]
+  end
+
+  module Auction_event_type = struct
+    module T = struct
+      type t = [ `Auction_open | `Auction_indicative_price | `Auction_outcome ]
+      [@@deriving sexp, enumerate]
+
+      let to_string = function
+        | `Auction_open -> "auction_open"
+        | `Auction_indicative_price -> "auction_indicative_price"
+        | `Auction_outcome -> "auction_outcome"
+    end
+
+    include T
+    include (Json.Make (T) : Json.S with type t := t)
+  end
+
+  module Auction_event = struct
+    type t =
+      [ `Auction_open of Auction_open_event.t
+      | `Auction_indicative_price of Auction_indicative_price_event.t
+      | `Auction_outcome of Auction_outcome_event.t ]
+    [@@deriving sexp]
+
+    let of_yojson : Yojson.Safe.t -> (t, string) Result.t = function
+      | `Assoc assoc as json -> (
+          List.Assoc.find assoc ~equal:String.equal "type" |> function
+          | None ->
+              Result.failf "no auction event type in json payload: %s"
+                (Yojson.Safe.to_string json)
+          | Some event_type -> (
+              Auction_event_type.of_yojson event_type |> function
+              | Result.Error _ as e -> e
+              | Result.Ok event_type -> (
+                  let json' =
+                    `Assoc (List.Assoc.remove ~equal:String.equal assoc "type")
+                  in
+                  match event_type with
+                  | `Auction_open ->
+                      Auction_open_event.of_yojson json'
+                      |> Result.map ~f:(fun event -> `Auction_open event)
+                  | `Auction_indicative_price ->
+                      Auction_indicative_price_event.of_yojson json'
+                      |> Result.map ~f:(fun event ->
+                             `Auction_indicative_price event)
+                  | `Auction_outcome ->
+                      Auction_outcome_event.of_yojson json'
+                      |> Result.map ~f:(fun event -> `Auction_outcome event))))
+      | #Yojson.Safe.t as json ->
+          Result.failf "expected association type in json payload: %s"
+            (Yojson.Safe.to_string json)
+  end
+
+  type event =
+    [ `Change of Change_event.t
+    | `Trade of Trade_event.t
+    | `Auction of Auction_event.t
+    | `Auction_open of Auction_open_event.t
+    | `Block_trade of Block_trade_event.t ]
+  [@@deriving sexp]
+
+  let event_of_yojson : Yojson.Safe.t -> (event, string) Result.t = function
+    | `Assoc assoc as json -> (
+        List.Assoc.find assoc ~equal:String.equal "type" |> function
+        | None ->
+            Result.failf "no event type in json payload: %s"
+              (Yojson.Safe.to_string json)
+        | Some event_type -> (
+            Event_type.of_yojson event_type |> function
+            | Result.Error _ as e -> e
+            | Result.Ok event_type -> (
+                let json' =
+                  `Assoc (List.Assoc.remove ~equal:String.equal assoc "type")
+                in
+                match event_type with
+                | `Change ->
+                    Change_event.of_yojson json'
+                    |> Result.map ~f:(fun event -> `Change event)
+                | `Trade ->
+                    Trade_event.of_yojson json'
+                    |> Result.map ~f:(fun event -> `Trade event)
+                | `Auction ->
+                    Auction_event.of_yojson json'
+                    |> Result.map ~f:(fun event -> `Auction event)
+                | `Auction_open ->
+                    Auction_open_event.of_yojson json'
+                    |> Result.map ~f:(fun event -> `Auction_open event)
+                | `Block_trade ->
+                    Block_trade_event.of_yojson json'
+                    |> Result.map ~f:(fun event -> `Block_trade event))))
+    | #Yojson.Safe.t as json ->
+        Result.failf "expected association type in json payload: %s"
+          (Yojson.Safe.to_string json)
+
+  module Update = struct
+    type t = {
+      event_id : Int_number.t; [@key "eventId"]
+      events : event array; [@default [||]]
+      timestamp : Timestamp.Sec.t option; [@default None]
+      timestampms : Timestamp.Ms.t option; [@default None]
+    }
+    [@@deriving sexp, of_yojson]
+  end
+
+  type message = [ `Heartbeat of heartbeat | `Update of Update.t ]
+  [@@deriving sexp]
+
+  type response = { socket_sequence : Int_number.t; message : message }
+  [@@deriving sexp]
+
+  let response_of_yojson : Yojson.Safe.t -> (response, string) Result.t =
+    function
+    | `Assoc assoc as json -> (
+        ( List.Assoc.find ~equal:String.equal assoc "socket_sequence",
+          List.Assoc.find ~equal:String.equal assoc "type" )
+        |> function
+        | None, _ ->
+            Result.failf "no sequence number in json payload: %s"
+              (Yojson.Safe.to_string json)
+        | _, None ->
+            Result.failf "no message type in json payload: %s"
+              (Yojson.Safe.to_string json)
+        | Some socket_sequence, Some message_type -> (
+            Result.both
+              (Int_number.of_yojson socket_sequence)
+              (Message_type.of_yojson message_type)
+            |> function
+            | Result.Error _ as e -> e
+            | Result.Ok (socket_sequence, message_type) ->
+                let json' =
+                  `Assoc
+                    ( List.Assoc.remove ~equal:String.equal assoc "type"
+                    |> fun assoc ->
+                      List.Assoc.remove ~equal:String.equal assoc
+                        "socket_sequence" )
+                in
+                (match message_type with
+                | `Heartbeat ->
+                    heartbeat_of_yojson json'
+                    |> Result.map ~f:(fun event -> `Heartbeat event)
+                | `Update ->
+                    Update.of_yojson json'
+                    |> Result.map ~f:(fun event -> `Update event))
+                |> Result.map ~f:(fun message -> { socket_sequence; message })))
+    | #Yojson.Safe.t as json ->
+        Result.failf
+          "response_of_yojson:expected association type in json payload: %s"
+          (Yojson.Safe.to_string json)
+
+  module Csv_of_event = Ws.Csv_of_event (Event_type)
+
+  let events_of_response (response : response) =
+    let csv_of_events = Csv_of_event.empty in
+    match response.message with
+    | `Heartbeat _ -> csv_of_events
+    | `Update (update : Update.t) ->
+        let event_id = update.event_id in
+        let timestamp =
+          Option.(
+            first_some update.timestamp update.timestamp
+            |> value ~default:(Time_float_unix.now ()))
+        in
+        Array.fold ~init:csv_of_events update.events
+          ~f:(fun csv_of_events (event : event) ->
+            match event with
+            | `Change change ->
+                Csv_of_event.add' csv_of_events `Change
+                  (module Change_event.Decorated)
+                  [ Change_event.to_decorated ~event_id ~timestamp change ]
+            | `Trade trade ->
+                Csv_of_event.add' csv_of_events `Trade
+                  (module Trade_event.Decorated)
+                  [ Trade_event.to_decorated ~event_id ~timestamp trade ]
+            | `Auction _auction -> csv_of_events
+            | `Auction_open _auction -> csv_of_events
+            | `Block_trade block_trade ->
+                Csv_of_event.add' csv_of_events `Block_trade
+                  (module Block_trade_event.Decorated)
+                  [
+                    Block_trade_event.to_decorated ~event_id ~timestamp
+                      block_trade;
+                  ])
+end
+
+include T
+include Ws.Make_no_request (T)

--- a/src/gemini/market_data.mli
+++ b/src/gemini/market_data.mli
@@ -1,0 +1,200 @@
+open! Common
+(** Market data websockets api for the Gemini trading exchange. This
+    broadcasts only public events and require no authentication.
+*)
+
+(** Encapsulates various concepts of side in the market dat api. *)
+module Side : sig
+  (** Represents a bid or ask side. *)
+  module Bid_ask : sig
+    type t = [ `Ask | `Bid ] [@@deriving sexp]
+
+    include Json.S with type t := t
+  end
+
+  (** Represents an auction style side. *)
+  module Auction : sig
+    type t = [ `Auction ] [@@deriving sexp]
+
+    include Json.S with type t := t
+  end
+
+  type t = [ Bid_ask.t | Auction.t ] [@@deriving sexp]
+  (** A most general type of side- one of [`Bid], [`Ask], or [`Auction]. *)
+
+  include Json.S with type t := t
+end
+
+(** Represents market data message types supported by the Gemini exchange. *)
+module Message_type : sig
+  (* The support message types for order events -
+     either [`Update] or [`Heartbeat].
+  *)
+  type t = [ `Heartbeat | `Update ] [@@deriving sexp]
+
+  include Json.S with type t := t
+end
+
+(** Represents different types of market data events *)
+module Event_type : sig
+  type t = [ `Trade | `Change | `Auction | `Auction_open | `Block_trade ]
+  [@@deriving sexp]
+  (** Market data event types. One of  [`Trade], [`Change], [`Auction],
+      or [`Block_trade].
+  *)
+
+  include Json.S with type t := t
+  include Comparable with type t := t
+end
+
+type heartbeat = unit [@@deriving sexp, of_yojson]
+(** The heartbeat response type has no payload *)
+
+(** Different reasons a market data event occured *)
+module Reason : sig
+  type t = [ `Place | `Trade | `Cancel | `Initial ] [@@deriving sexp]
+  (** Reasons a market data event occured *)
+
+  include Json.S with type t := t
+end
+
+(** An change event to an order. The [reaosn] field indicates
+    the type of change. *)
+module Change_event : sig
+  type t = {
+    price : Decimal_string.t;
+    side : Side.Bid_ask.t;
+    reason : Reason.t;
+    remaining : Decimal_string.t;
+    delta : Decimal_string.t;
+  }
+  [@@deriving sexp, of_yojson, csv, fields]
+end
+
+(** An trade event of an order. *)
+module Trade_event : sig
+  type t = {
+    tid : Int_number.t;
+    price : Decimal_string.t;
+    amount : Decimal_string.t;
+    maker_side : Side.t;
+  }
+  [@@deriving sexp, of_yojson, fields, csv]
+end
+
+(** A block trade event. *)
+module Block_trade_event : sig
+  type t = { price : Decimal_string.t; amount : Decimal_string.t }
+  [@@deriving sexp, of_yojson, fields, csv]
+end
+
+(** An auction open event. *)
+module Auction_open_event : sig
+  type t = {
+    auction_open_ms : Timestamp.Ms.t;
+    auction_time_ms : Timestamp.Ms.t;
+    first_indicative_ms : Timestamp.Ms.t;
+    last_cancel_time_ms : Timestamp.Ms.t;
+  }
+  [@@deriving sexp, of_yojson, fields, csv]
+end
+
+(** Represents different results possible from an auction. *)
+module Auction_result : sig
+  type t = [ `Success | `Failure ] [@@deriving sexp]
+  (** the type of an auction result- one of [`Success] or [`Failure]. *)
+
+  include Json.S with type t := t
+end
+
+(** An auction indicative price event. *)
+module Auction_indicative_price_event : sig
+  type t = {
+    eid : Int_number.t;
+    result : Auction_result.t;
+    time_ms : Timestamp.Ms.t;
+    highest_bid_price : Decimal_string.t;
+    lowest_ask_price : Decimal_string.t;
+    collar_price : Decimal_string.t;
+    indicative_price : Decimal_string.t;
+    indicative_quantity : Decimal_string.t;
+  }
+  [@@deriving sexp, of_yojson, fields, csv]
+end
+
+(** An auction outcome event. *)
+module Auction_outcome_event : sig
+  type t = {
+    eid : Int_number.t;
+    result : Auction_result.t;
+    time_ms : Timestamp.Ms.t;
+    highest_bid_price : Decimal_string.t;
+    lowest_ask_price : Decimal_string.t;
+    collar_price : Decimal_string.t;
+    auction_price : Decimal_string.t;
+    auction_quantity : Decimal_string.t;
+  }
+  [@@deriving sexp, of_yojson, fields, csv]
+end
+
+(** Represents different auction event types. *)
+module Auction_event_type : sig
+  type t = [ `Auction_open | `Auction_indicative_price | `Auction_outcome ]
+  [@@deriving sexp]
+  (** Enumerates an auction event type. *)
+
+  include Json.S with type t := t
+end
+
+module Auction_event : sig
+  type t =
+    [ `Auction_indicative_price of Auction_indicative_price_event.t
+    | `Auction_open of Auction_open_event.t
+    | `Auction_outcome of Auction_outcome_event.t ]
+  [@@deriving sexp, of_yojson]
+  (** The type of an auction event, unified over all auction event types. *)
+end
+
+type event =
+  [ `Auction of Auction_event.t
+  | `Auction_open of Auction_open_event.t
+  | `Change of Change_event.t
+  | `Trade of Trade_event.t
+  | `Block_trade of Block_trade_event.t ]
+[@@deriving sexp, of_yojson]
+(** The type of event, unified over auction, change, and trade events. *)
+
+(** The type of a market data update message. *)
+module Update : sig
+  type t = {
+    event_id : Int_number.t;
+    events : event array;
+    timestamp : Timestamp.Sec.t option;
+    timestampms : Timestamp.Ms.t option;
+  }
+  [@@deriving sexp, of_yojson]
+end
+
+type message = [ `Heartbeat of heartbeat | `Update of Update.t ]
+[@@deriving sexp]
+(** The type of a market data message- a heartbeat or update. *)
+
+type response = { socket_sequence : Int_number.t; message : message }
+[@@deriving sexp]
+(** The type of a market data response. *)
+
+include
+  Ws.CHANNEL
+    with module Event_type := Event_type
+    with type uri_args = Symbol.t
+    with type query = unit
+    with type response := response
+
+val client :
+  (module Cfg.S) ->
+  ?query:Sexp.t list ->
+  ?uri_args:uri_args ->
+  unit ->
+  response Pipe.Reader.t Deferred.t
+
+val command : string * Command.t

--- a/src/gemini/nonce.ml
+++ b/src/gemini/nonce.ml
@@ -1,0 +1,82 @@
+type reader = int Inf_pipe.Reader.t
+
+module type S = sig
+  type t [@@deriving sexp]
+
+  val pipe : init:t -> unit -> int Inf_pipe.Reader.t Deferred.t
+end
+
+module Counter : S with type t = int = struct
+  type t = int [@@deriving sexp]
+
+  let pipe ~init () =
+    Inf_pipe.unfold ~init ~f:(fun s ->
+        let s' = s + 1 in
+        (s, s') |> return)
+    |> return
+end
+
+module File = struct
+  let create_nonce_file ?(default = 0) filename =
+    try_with ~extract_exn:true (fun () ->
+        Unix.with_file ~mode:[ `Rdonly ] filename ~f:(fun _fd -> Deferred.unit))
+    >>= function
+    | Result.Ok _ -> Deferred.unit
+    | Result.Error _ -> Writer.save ~contents:(sprintf "%d\n" default) filename
+
+  type t = string [@@deriving sexp]
+
+  (* TODO - too expensive- only check the file once, then do
+   * everything in memory *)
+  let pipe ~init:filename () =
+    Cfg.create_config_dir () >>= fun () ->
+    create_nonce_file ?default:None filename >>= fun () ->
+    Inf_pipe.unfold ~init:() ~f:(fun _ ->
+        (Reader.open_file ?buf_len:None filename
+         >>= Reader.really_read_line ~wait_time:(Time_float_unix.Span.of_ms 1.0)
+         >>= function
+         | None -> return 0
+         | Some nonce -> return @@ Int.of_string nonce)
+        >>= fun nonce ->
+        let nonce' = nonce + 1 in
+        Writer.save filename ~contents:(sprintf "%d\n" nonce') >>= fun () ->
+        return (nonce, ()))
+    |> return
+
+  let default_filename =
+    let root_path = Unix.getenv_exn "HOME" in
+    sprintf "%s/.gemini/nonce.txt" root_path
+end
+
+let _assert_module_file_is_nonce =
+  let module F : S with type t = string = File in
+  ()
+
+module Request = struct
+  type request_nonce = { request : string; nonce : int }
+  [@@deriving sexp, yojson]
+
+  type t = {
+    request : string;
+    nonce : int;
+    payload : Yojson.Safe.t option; [@default None]
+  }
+
+  let make ~request ~nonce ?payload () =
+    Inf_pipe.read nonce >>= fun nonce -> return { request; nonce; payload }
+
+  let to_yojson { request; nonce; payload } : Yojson.Safe.t =
+    match request_nonce_to_yojson { request; nonce } with
+    | `Assoc assoc as a -> (
+        match Option.value ~default:`Null payload with
+        | `Null -> a
+        | `Assoc assoc' -> `Assoc (assoc @ assoc')
+        | #Yojson.Safe.t as unsupported_yojson ->
+            failwithf "expected json association for request payload but got %S"
+              (Yojson.Safe.to_string unsupported_yojson)
+              ())
+    | #Yojson.Safe.t as unsupported_yojson ->
+        failwithf "expected json association for type request_nonce but got %S"
+          (Yojson.Safe.to_string unsupported_yojson)
+          ()
+end

--- a/src/gemini/order_events.ml
+++ b/src/gemini/order_events.ml
@@ -1,0 +1,272 @@
+open Common
+module Request = Nonce.Request
+
+module T = struct
+  let name = "orderevents"
+  let version = v1
+  let path = version :: [ "order"; "events" ]
+
+  type uri_args = [ `None ] [@@deriving sexp, enumerate]
+
+  let authentication = `Private
+  let default_uri_args = None
+
+  let encode_uri_args _ =
+    failwith "uri path arguments not support for order events"
+
+  type heartbeat = {
+    timestampms : Timestamp.Ms.t;
+    sequence : Int_number.t;
+    trace_id : string;
+    socket_sequence : Int_number.t;
+  }
+  [@@deriving sexp, yojson]
+
+  module Order_event_type = struct
+    module T = struct
+      type t =
+        [ `Subscription_ack
+        | `Heartbeat
+        | `Initial
+        | `Accepted
+        | `Rejected
+        | `Booked
+        | `Fill
+        | `Cancelled
+        | `Closed ]
+      [@@deriving sexp, enumerate, compare]
+
+      let to_string : t -> string = function
+        | `Subscription_ack -> "subscription_ack"
+        | `Heartbeat -> "heartbeat"
+        | `Initial -> "initial"
+        | `Accepted -> "accepted"
+        | `Rejected -> "rejected"
+        | `Booked -> "booked"
+        | `Fill -> "fill"
+        | `Cancelled -> "cancelled"
+        | `Closed -> "closed"
+    end
+
+    include T
+    include Comparable.Make (T)
+    include (Json.Make (T) : Json.S with type t := t)
+  end
+
+  type query =
+    [ `Symbol_filter of Symbol.t
+    | `Event_type_filter of Order_event_type.t
+    | `Api_session_filter of string ]
+  [@@deriving sexp]
+
+  let encode_query = function
+    | `Symbol_filter symbol -> ("symbolFilter", Symbol.to_string symbol)
+    | `Event_type_filter event_type ->
+        ("eventTypeFilter", Order_event_type.to_string event_type)
+    | `Api_session_filter session -> ("apiSessionFilter", session)
+
+  module Reason = struct
+    module T = struct
+      type t = [ `Place | `Trade | `Cancel | `Initial ]
+      [@@deriving sexp, enumerate]
+
+      let to_string = function
+        | `Place -> "place"
+        | `Trade -> "trade"
+        | `Cancel -> "cancel"
+        | `Initial -> "initial"
+    end
+
+    include T
+    include (Json.Make (T) : Json.S with type t := t)
+  end
+
+  module Reject_reason = struct
+    module T = struct
+      type t = [ `Invalid_quantity ] [@@deriving sexp, enumerate]
+
+      let to_string = function `Invalid_quantity -> "InvalidQuantity"
+    end
+
+    include T
+    include (Json.Make (T) : Json.S with type t := t)
+  end
+
+  module Liquidity = struct
+    module T = struct
+      type t = [ `Taker ] [@@deriving sexp, enumerate]
+
+      (* TODO determine other liquidities *)
+      let to_string = function `Taker -> "Taker"
+    end
+
+    include T
+    include (Json.Make (T) : Json.S with type t := t)
+  end
+
+  module Fill = struct
+    type t = {
+      trade_id : Int_string.t;
+      liquidity : Liquidity.t;
+      price : Decimal_string.t;
+      amount : Decimal_string.t;
+      fee : Decimal_string.t;
+      fee_currency : Currency.t;
+    }
+    [@@deriving sexp, yojson, fields, csv]
+  end
+
+  module Api_session = struct
+    (* TODO make an enum from UI, and whatever the other values are *)
+    type t = string [@@deriving sexp, yojson]
+
+    include (
+      Csvfields.Csv.Atom (String) : Csvfields.Csv.Csvable with type t := t)
+  end
+
+  module Decimal_string_option =
+    Csv_support.Optional.Make (Csv_support.Optional.Default_args (Decimal_string))
+
+  module Fill_option = struct
+    module T = struct
+      type t = Fill.t option [@@deriving yojson, sexp]
+
+      let of_string = function
+        | "" -> None
+        | s -> String.split ~on:' ' s |> Fill.t_of_row |> Option.some
+
+      let to_string = function
+        | None -> ""
+        | Some fill -> Fill.row_of_t fill |> String.concat ~sep:" "
+    end
+
+    include T
+    include (Csvfields.Csv.Atom (T) : Csvfields.Csv.Csvable with type t := t)
+  end
+
+  module Reject_reason_option = Csv_support.Optional.Make_default (Reject_reason)
+
+  module Order_event = struct
+    open Csv_support
+
+    type t = {
+      order_id : string;
+      api_session : Api_session.t;
+      client_order_id : Optional.String.t; [@default None]
+      event_id : Optional.String.t; [@default None]
+      order_type : Order_type.t;
+      symbol : Symbol.t;
+      reason : Reject_reason_option.t; [@default None]
+      side : Side.t;
+      behavior : Optional.String.t; [@default None] (* TODO make enum *)
+      type_ : Order_event_type.t; [@key "type"]
+      timestamp : Timestamp.t;
+      timestampms : Timestamp.Ms.t;
+      is_live : bool;
+      is_cancelled : bool;
+      is_hidden : bool;
+      avg_execution_price : Decimal_string_option.t; [@default None]
+      executed_amount : Decimal_string_option.t; [@default None]
+      remaining_amount : Decimal_string_option.t; [@default None]
+      original_amount : Decimal_string_option.t; [@default None]
+      price : Decimal_string_option.t; [@default None]
+      total_spend : Decimal_string_option.t; [@default None]
+      fill : Fill_option.t; [@default None]
+      socket_sequence : Int_number.t;
+    }
+    [@@deriving sexp, yojson, fields, csv]
+  end
+
+  module Event_type_list = Csv_support.List.Make_default (Order_event_type)
+  module Symbol_list = Csv_support.List.Make_default (Symbol)
+
+  module Subscription_ack = struct
+    type t = {
+      account_id : Int_number.t; [@key "accountId"]
+      subscription_id : string; [@key "subscriptionId"]
+      symbol_filter : Symbol_list.t; [@key "symbolFilter"]
+      api_session_fiter : Csv_support.List.String.t; [@key "apiSessionFilter"]
+      event_type_filter : Event_type_list.t; [@key "eventTypeFilter"]
+    }
+    [@@deriving sexp, yojson, fields, csv]
+  end
+
+  type response =
+    [ `Subscription_ack of Subscription_ack.t
+    | `Heartbeat of heartbeat
+    | `Order_event of Order_event.t
+    | `Order_events of Order_event.t list ]
+  [@@deriving sexp]
+
+  let response_of_yojson : Yojson.Safe.t -> ('a, string) Result.t = function
+    | `Assoc assoc as json -> (
+        List.Assoc.find assoc ~equal:String.equal "type" |> function
+        | None ->
+            Log.Global.debug "no type in event payload: %s"
+              (Yojson.Safe.to_string json);
+            Subscription_ack.of_yojson json
+            |> Result.map ~f:(fun event -> `Subscription_ack event)
+        | Some event_type -> (
+            Log.Global.debug "found type in event payload: %s"
+              (Yojson.Safe.to_string json);
+            Order_event_type.of_yojson event_type |> function
+            | Result.Error _ as e -> e
+            | Result.Ok event_type -> (
+                let json' =
+                  `Assoc (List.Assoc.remove ~equal:String.equal assoc "type")
+                in
+                match event_type with
+                | `Heartbeat ->
+                    heartbeat_of_yojson json'
+                    |> Result.map ~f:(fun event -> `Heartbeat event)
+                | `Subscription_ack ->
+                    Subscription_ack.of_yojson json'
+                    |> Result.map ~f:(fun event -> `Subscription_ack event)
+                | #Order_event_type.t ->
+                    Order_event.of_yojson json
+                    |> Result.map ~f:(fun event -> `Order_event event))))
+    | (`List l : Yojson.Safe.t) ->
+        Result.(
+          all (List.map l ~f:Order_event.of_yojson)
+          |> map ~f:(fun x -> `Order_events x))
+    | #Yojson.Safe.t as json ->
+        Result.failf "expected association type in json payload: %s"
+          (Yojson.Safe.to_string json)
+
+  module Event_type = struct
+    module T = struct
+      type t = [ `Order_event | `Subscription_ack ]
+      [@@deriving sexp, yojson, enumerate, compare]
+
+      let to_string = function
+        | `Order_event -> "order_event"
+        | `Subscription_ack -> "subscription_ack"
+    end
+
+    include T
+    include Comparable.Make (T)
+    include (Json.Make (T) : Json.S with type t := t)
+  end
+
+  module Csv_of_event = Ws.Csv_of_event (Event_type)
+
+  let events_of_response (response : response) =
+    let csv_of_event = Csv_of_event.empty in
+    match response with
+    | `Order_event order_event ->
+        Csv_of_event.add' csv_of_event `Order_event
+          (module Order_event)
+          [ order_event ]
+    | `Heartbeat _ -> csv_of_event
+    | `Order_events order_events ->
+        Csv_of_event.add' csv_of_event `Order_event
+          (module Order_event)
+          order_events
+    | `Subscription_ack ack ->
+        Csv_of_event.add' csv_of_event `Subscription_ack
+          (module Subscription_ack)
+          [ ack ]
+end
+
+include T
+include Ws.Make (T)

--- a/src/gemini/order_events.mli
+++ b/src/gemini/order_events.mli
@@ -1,0 +1,166 @@
+(** Order events web sockets api for the gemini trading exchange. This
+    is used to get private events about orders and trades without having to
+    depend on the slower and clumsier json REST api. Users still must submit
+    orders using REST, however. This is only for responses.
+*)
+
+open Common
+module Request = Nonce.Request
+
+type uri_args = [ `None ] [@@deriving sexp, enumerate]
+(** The order events api has no uri arguments .*)
+
+type heartbeat = {
+  timestampms : Timestamp.Ms.t;
+  sequence : Int_number.t;
+  trace_id : string;
+  socket_sequence : Int_number.t;
+}
+[@@deriving sexp, yojson]
+(** Response type for heart beat messages. *)
+
+(** Represents different order event types. *)
+module Order_event_type : sig
+  type t =
+    [ `Subscription_ack
+    | `Heartbeat
+    | `Initial
+    | `Accepted
+    | `Rejected
+    | `Booked
+    | `Fill
+    | `Cancelled
+    | `Closed ]
+  [@@deriving sexp, enumerate, compare]
+  (** Enumerates all possible order events. *)
+
+  include Json.S with type t := t
+  include Comparable with type t := t
+end
+
+type query =
+  [ `Symbol_filter of Symbol.t
+  | `Event_type_filter of Order_event_type.t
+  | `Api_session_filter of string ]
+[@@deriving sexp]
+(** Events can be filtered by symbol using [Symbol_filter symbol] or
+    for an event type using [Order_event_type_filter event_type] or using
+    an api session filter [Api_session_filter session-id].
+*)
+
+(** Represents differents reasons an order event occurred. *)
+module Reason : sig
+  type t = [ `Place | `Trade | `Cancel | `Initial ] [@@deriving sexp, enumerate]
+
+  include Json.ENUM_STRING with type t := t
+end
+
+module Reject_reason : sig
+  type t = [ `Invalid_quantity ] [@@deriving sexp, enumerate]
+
+  include Json.ENUM_STRING with type t := t
+end
+
+(** Represents different liquidity types *)
+module Liquidity : sig
+  type t = [ `Taker ] [@@deriving sexp, enumerate]
+  (** [Taker] is the only known liquidity type but this
+      is poorly documented so other values might exist.
+  *)
+
+  include Json.ENUM_STRING with type t := t
+end
+
+(** Type type of an order fill event. *)
+module Fill : sig
+  type t = {
+    trade_id : Int_string.t;
+    liquidity : Liquidity.t;
+    price : Decimal_string.t;
+    amount : Decimal_string.t;
+    fee : Decimal_string.t;
+    fee_currency : Currency.t;
+  }
+  [@@deriving sexp, yojson, fields, csv]
+end
+
+(** Represents an api session name *)
+module Api_session : sig
+  type t = string [@@deriving sexp, yojson]
+  (** An api session name. *)
+end
+
+module Order_event : sig
+  type t = {
+    order_id : string;
+    api_session : Api_session.t;
+    client_order_id : string option; [@default None]
+    event_id : string option; [@default None]
+    order_type : Order_type.t;
+    symbol : Symbol.t;
+    reason : Reject_reason.t option; [@default None]
+    side : Side.t;
+    behavior : string option; [@default None]
+    type_ : Order_event_type.t; [@key "type"]
+    timestamp : Timestamp.t;
+    timestampms : Timestamp.Ms.t;
+    is_live : bool;
+    is_cancelled : bool;
+    is_hidden : bool;
+    avg_execution_price : Decimal_string.t option; [@default None]
+    executed_amount : Decimal_string.t option; [@default None]
+    remaining_amount : Decimal_string.t option; [@default None]
+    original_amount : Decimal_string.t option; [@default None]
+    price : Decimal_string.t option; [@default None]
+    total_spend : Decimal_string.t option; [@default None]
+    fill : Fill.t option; [@default None]
+    socket_sequence : Int_number.t;
+  }
+  [@@deriving sexp, yojson, fields, csv]
+  (** The type of an order event. *)
+end
+
+module Subscription_ack : sig
+  type t = {
+    account_id : Int_number.t; [@key "accountId"]
+    subscription_id : string; [@key "subscriptionId"]
+    symbol_filter : Symbol.t list; [@key "symbolFilter"]
+    api_session_fiter : string list; [@key "apiSessionFilter"]
+    event_type_filter : Order_event_type.t list; [@key "eventTypeFilter"]
+  }
+  [@@deriving sexp, yojson, fields, csv]
+  (** The type of a subscription acknowledgement event. *)
+end
+
+type response =
+  [ `Subscription_ack of Subscription_ack.t
+  | `Heartbeat of heartbeat
+  | `Order_event of Order_event.t
+  | `Order_events of Order_event.t list ]
+[@@deriving sexp]
+(** The response type for any order message. *)
+
+module Event_type : sig
+  type t = [ `Order_event | `Subscription_ack ]
+  [@@deriving sexp, enumerate, compare]
+
+  include Comparable.S with type t := t
+  include Json.S with type t := t
+end
+
+include
+  Ws.CHANNEL
+    with module Event_type := Event_type
+    with type uri_args := uri_args
+    with type query := query
+    with type response := response
+
+val command : string * Async.Command.t
+
+val client :
+  nonce:int Inf_pipe.Reader.t ->
+  (module Cfg.S) ->
+  ?query:Sexp.t list ->
+  ?uri_args:uri_args ->
+  unit ->
+  response Pipe.Reader.t Deferred.t

--- a/src/gemini/path.ml
+++ b/src/gemini/path.ml
@@ -1,0 +1,14 @@
+(** Path utilities for encoding them into uris or human readable formats. *)
+
+type t = string list
+(** The type of a uri path *)
+
+(** Produces the string representation of a path
+   suitable for a uri encoding. *)
+let to_string (path : t) = sprintf "/%s" (String.concat ~sep:"/" path)
+
+(** Summarize the path in a human readable format. *)
+let to_summary ~has_subnames (path : t) =
+  sprintf "Gemini %s Command%s"
+    (String.concat ~sep:" " path)
+    (match has_subnames with true -> "s" | false -> "")

--- a/src/gemini/rest.ml
+++ b/src/gemini/rest.ml
@@ -1,0 +1,179 @@
+module Error = struct
+  type http =
+    [ `Bad_request of string
+    | `Not_found
+    | `Service_unavailable of string
+    | `Not_acceptable of string
+    | `Unauthorized of string ]
+  [@@deriving sexp]
+
+  type json_error = { message : string; body : string } [@@deriving sexp]
+  type json = [ `Json_parse_error of json_error ] [@@deriving sexp]
+  type detail = { reason : string; message : string } [@@deriving sexp, yojson]
+  type response = [ `Error of detail ] [@@deriving sexp]
+  type post = [ http | json | response ] [@@deriving sexp]
+end
+
+module Operation = struct
+  module type S = sig
+    val name : string
+    val path : string list
+
+    type request [@@deriving sexp, to_yojson]
+    type response [@@deriving sexp, of_yojson]
+  end
+
+  module type S_NO_ARG = sig
+    include S with type request = unit
+  end
+end
+
+module Request = Nonce.Request
+
+module Response = struct
+  module Json_result = struct
+    module T = struct
+      type t = [ `Error | `Ok ] [@@deriving sexp, enumerate]
+
+      let to_string = function `Error -> "error" | `Ok -> "ok"
+    end
+
+    include T
+    include (Json.Make (T) : Json.S with type t := t)
+
+    let split = function
+      | `Assoc assoc as json -> (
+          List.Assoc.find assoc ~equal:String.equal "result" |> function
+          | None -> Result.Ok (None, json)
+          | Some json' ->
+              of_yojson json'
+              |> Result.map ~f:(fun x ->
+                     ( Some x,
+                       `Assoc
+                         (List.Assoc.remove assoc ~equal:String.equal "result")
+                     )))
+      | #Yojson.Safe.t as json -> Result.Ok (None, json)
+  end
+
+  type result_field = { result : Json_result.t } [@@deriving of_yojson, sexp]
+  type t = { result : Json_result.t; payload : Yojson.Safe.t }
+
+  let parse json ok_of_yojson =
+    match Json_result.split json with
+    | Result.Ok (result, payload) -> (
+        match result with
+        | None | Some `Ok -> (
+            ok_of_yojson payload |> function
+            | Result.Ok x -> `Ok x
+            | Result.Error e ->
+                `Json_parse_error
+                  Error.{ message = e; body = Yojson.Safe.to_string payload })
+        | Some `Error -> (
+            Error.detail_of_yojson payload |> function
+            | Result.Ok x -> `Error x
+            | Result.Error e ->
+                `Json_parse_error
+                  Error.{ message = e; body = Yojson.Safe.to_string payload }))
+    | Result.Error e ->
+        `Json_parse_error
+          Error.{ message = e; body = Yojson.Safe.to_string json }
+end
+
+module Post (Operation : Operation.S) : sig
+  val post :
+    (module Cfg.S) ->
+    Nonce.reader ->
+    Operation.request ->
+    [ `Ok of Operation.response | Error.post ] Deferred.t
+end = struct
+  let post (module Cfg : Cfg.S) (nonce : Nonce.reader)
+      (request : Operation.request) :
+      [ `Ok of Operation.response | Error.post ] Deferred.t =
+    let payload = Operation.request_to_yojson request in
+    let path = Path.to_string Operation.path in
+    Request.make ~nonce ~request:path ~payload () >>= fun request ->
+    ( Request.to_yojson request |> Yojson.Safe.pretty_to_string |> fun s ->
+      Log.Global.debug "request as json:\n %s" s;
+      return @@ Auth.of_payload s )
+    >>= fun payload ->
+    let headers = Auth.to_headers (module Cfg) payload in
+    let uri =
+      Uri.make ~scheme:"https" ~host:Cfg.api_host ~path ?query:None ()
+    in
+    Cohttp_async.Client.post ~headers ?chunked:None ?interrupt:None
+      ?ssl_config:None ?body:None uri
+    >>= fun (response, body) ->
+    match Cohttp.Response.status response with
+    | `OK ->
+        Cohttp_async.Body.to_string body >>| fun s ->
+        Log.Global.debug "result as json:\n %s" s;
+        let yojson = Yojson.Safe.from_string s in
+        Response.parse yojson Operation.response_of_yojson
+    | `Not_found -> return `Not_found
+    | `Not_acceptable ->
+        Cohttp_async.Body.to_string body >>| fun body -> `Not_acceptable body
+    | `Bad_request ->
+        Cohttp_async.Body.to_string body >>| fun body -> `Bad_request body
+    | `Service_unavailable ->
+        Cohttp_async.Body.to_string body >>| fun body ->
+        `Service_unavailable body
+    | (code : Cohttp.Code.status_code) ->
+        Cohttp_async.Body.to_string body >>| fun body ->
+        failwiths ~here:[%here]
+          (sprintf "unexpected status code (body=%S)" body)
+          code Cohttp.Code.sexp_of_status_code
+end
+
+module Make (Operation : Operation.S) = struct
+  include Post (Operation)
+
+  let command =
+    let open Command.Let_syntax in
+    ( Operation.name,
+      Command.async
+        ~summary:(Path.to_summary ~has_subnames:false Operation.path)
+        [%map_open
+          let config = Cfg.param and request = anon ("request" %: sexp) in
+          fun () ->
+            let request = Operation.request_of_sexp request in
+            Log.Global.info "request:\n %s"
+              (Operation.sexp_of_request request |> Sexp.to_string);
+            let config = Cfg.or_default config in
+            Nonce.File.(pipe ~init:default_filename) () >>= fun nonce ->
+            post config nonce request >>= function
+            | `Ok response ->
+                Log.Global.info "response:\n %s"
+                  (Sexp.to_string_hum (Operation.sexp_of_response response));
+                Log.Global.flushed ()
+            | #Error.post as post_error ->
+                failwiths ~here:[%here]
+                  (sprintf "post for operation %S failed"
+                     (Path.to_string Operation.path))
+                  post_error Error.sexp_of_post] )
+end
+
+module Make_no_arg (Operation : Operation.S_NO_ARG) = struct
+  include Post (Operation)
+
+  let command =
+    let open Command.Let_syntax in
+    ( Operation.name,
+      Command.async
+        ~summary:(Path.to_summary ~has_subnames:false Operation.path)
+        [%map_open
+          let config = Cfg.param in
+          fun () ->
+            let request = () in
+            let config = Cfg.or_default config in
+            Nonce.File.(pipe ~init:default_filename) () >>= fun nonce ->
+            post config nonce request >>= function
+            | `Ok response ->
+                Log.Global.info "response:\n %s"
+                  (Sexp.to_string_hum (Operation.sexp_of_response response));
+                Log.Global.flushed ()
+            | #Error.post as post_error ->
+                failwiths ~here:[%here]
+                  (sprintf "post for operation %S failed"
+                     (Path.to_string Operation.path))
+                  post_error Error.sexp_of_post] )
+end

--- a/src/gemini/rest.mli
+++ b/src/gemini/rest.mli
@@ -1,0 +1,119 @@
+(** REST api support for the Gemini trading exchange. These endpoints are used
+    to manage orders and check balances. *)
+
+(** Represents all error conditions possible by the REST services. In general
+    the REST services don't throw exceptions- instead they report an error
+    variant with some provisional failure information. *)
+module Error : sig
+  type http =
+    [ `Bad_request of string
+    | `Not_found
+    | `Service_unavailable of string
+    | `Not_acceptable of string
+    | `Unauthorized of string ]
+  [@@deriving sexp]
+  (** An error at the http protocol level. Each variant is named according
+      to it's corresponding http status code. The body of the http response
+      is append to the variant payload if it exists. *)
+
+  type json_error = { message : string; body : string } [@@deriving sexp]
+  (** An error type indicating a json parse error. *)
+
+  type json = [ `Json_parse_error of json_error ] [@@deriving sexp]
+  (** Json level error conditions. *)
+
+  type detail = { reason : string; message : string } [@@deriving sexp, yojson]
+  (** Used to provide more details on a particular error condition *)
+
+  type response = [ `Error of detail ] [@@deriving sexp]
+  (** Application level error conditions *)
+
+  type post = [ http | json | response ] [@@deriving sexp]
+  (** Any error condition possible from an http post request *)
+end
+
+module Request = Nonce.Request
+
+(** Operations denote a single REST operation endpoint. *)
+module Operation : sig
+  (** Minimal specification to define a new REST operation. *)
+  module type S = sig
+    val name : string
+    (** The human readable name of this operation. *)
+
+    val path : string list
+    (** The uri path of the REST endpoint. *)
+
+    type request [@@deriving sexp, to_yojson]
+    (** The type of the request payload for this REST endpoint. *)
+
+    type response [@@deriving sexp, of_yojson]
+    (** The type of the response payload for this REST endpoint. *)
+  end
+
+  (** A REST operation endpoint which takes no request parameters. *)
+  module type S_NO_ARG = sig
+    include S with type request = unit
+  end
+end
+
+(** Support for parsing responses from a Gemini api REST endpoint. *)
+module Response : sig
+  module Json_result : sig
+    type t = [ `Error | `Ok ] [@@derivin sexp, yojson, enumerate]
+
+    val to_string : t -> string
+    val dict : (string * t) list
+    val of_string : string -> t
+    val of_string_opt : string -> t option
+
+    val split :
+      [< Yojson.Safe.t ] -> (t option * [> Yojson.Safe.t ], string) result
+  end
+
+  type result_field = { result : Json_result.t } [@@deriving sexp, of_yojson]
+  type t = { result : Json_result.t; payload : Yojson.Safe.t }
+
+  val parse :
+    Yojson.Safe.t ->
+    ([> Yojson.Safe.t ] -> ('a, string) result) ->
+    [ `Error of Error.detail
+    | `Json_parse_error of Error.json_error
+    | `Ok of 'a ]
+end
+
+(** Creates a REST endpoint using the http post method with
+    operation specified by provided module [Operation] *)
+module Post : functor (Operation : Operation.S) -> sig
+  val post :
+    (module Cfg.S) ->
+    Nonce.reader ->
+    Operation.request ->
+    [ `Ok of Operation.response | Error.post ] Deferred.t
+end
+
+(** Creates a REST endpoint using the http post method with
+    operation specified by provided module [Operation].
+    Also produces a command line interface hook. *)
+module Make : functor (Operation : Operation.S) -> sig
+  val post :
+    (module Cfg.S) ->
+    Nonce.reader ->
+    Operation.request ->
+    [ `Ok of Operation.response | Error.post ] Deferred.t
+
+  val command : string * Core.Command.t
+end
+
+(** Creates a REST endpoint using the http post method with no argument
+    operation specified by provided module [Operation].
+    Also produces a command line interface hook. *)
+module Make_no_arg : functor (Operation : Operation.S_NO_ARG) -> sig
+  val post :
+    (module Cfg.S) ->
+    Nonce.reader ->
+    unit ->
+    [ Error.post | `Ok of Operation.response ] Deferred.t
+
+  val command : string * Core.Command.t
+end

--- a/src/gemini/ws.ml
+++ b/src/gemini/ws.ml
@@ -1,0 +1,356 @@
+(** Websocket api support for the gemini trading exchange. *)
+
+module type CSVABLE = Csvfields.Csv.Csvable
+
+module type EVENT_CSVABLE = sig
+  include CSVABLE
+
+  val events : t list
+end
+
+module type CSV_OF_EVENTS = sig
+  module Event_type : sig
+    include Json.S
+
+    val equal : t -> t -> bool
+  end
+
+  type t
+
+  val empty : t
+  val add : t -> Event_type.t -> (module EVENT_CSVABLE) -> t
+
+  val add' :
+    t -> Event_type.t -> (module CSVABLE with type t = 'a) -> 'a list -> t
+
+  val csv_header : t -> Event_type.t -> string list option
+  val get : t -> Event_type.t -> string list list
+  val all : t -> (Event_type.t * string list list) list
+  val write : ?dir:string -> t -> Event_type.t -> int
+  val write_all : ?dir:string -> t -> (Event_type.t * int) list
+end
+
+module Csv_of_event (Event_type : sig
+  include Json.S
+  include Comparable with type t := t
+end) : CSV_OF_EVENTS with module Event_type = Event_type = struct
+  type t = (module EVENT_CSVABLE) list Event_type.Map.t
+
+  let empty : t = Event_type.Map.empty
+
+  module Event_type = Event_type
+
+  let add (t : t) (event_type : Event_type.t) (module Event : EVENT_CSVABLE) =
+    Map.add_multi t ~key:event_type
+      ~data:(module Event : EVENT_CSVABLE)
+
+  let add' (t : t) (type event) (event_type : Event_type.t)
+      (module Event : CSVABLE with type t = event) (events : event list) =
+    let module E = struct
+      include Event
+
+      let events = events
+    end in
+    add t event_type (module E)
+
+  let csv_header (t : t) event_type =
+    Map.find_multi t event_type
+    |> List.hd
+    |> Option.map ~f:(fun (module Event : EVENT_CSVABLE) -> Event.csv_header)
+
+  let get (t : t) (event_type : Event_type.t) =
+    Map.find_multi t event_type
+    |> List.concat_map ~f:(fun (module Event : EVENT_CSVABLE) ->
+           Event.events |> List.map ~f:Event.row_of_t)
+
+  let write ?dir (t : t) (event_type : Event_type.t) =
+    let dir = match dir with None -> Core_unix.getcwd () | Some dir -> dir in
+    let filename =
+      Filename.concat dir (sprintf "%s.csv" (Event_type.to_string event_type))
+    in
+    let header =
+      try
+        let stat = Core_unix.stat filename in
+        if Int64.(equal stat.st_size zero) then csv_header t event_type
+        else (
+          Log.Global.debug "ws: no csv header";
+          None)
+      with _error ->
+        (* This looks confusing, simplify or document *)
+        Log.Global.debug "ws: getting csv header";
+        csv_header t event_type
+    in
+    Out_channel.with_file ~append:true ~binary:false ~fail_if_exists:false
+      filename ~f:(fun out ->
+        Option.iter header ~f:(fun header ->
+            Csv_support.write_header out header);
+        Map.find_multi t event_type
+        |> List.fold ~init:0 ~f:(fun acc (module Event : EVENT_CSVABLE) ->
+               let events = Event.events in
+               let len = List.length events in
+               Event.csv_save_out out events;
+               acc + len))
+
+  let all (t : t) =
+    List.filter_map Event_type.all ~f:(fun e ->
+        match get t e with [] -> None | x -> Some (e, x))
+
+  let write_all ?dir (t : t) =
+    List.map Event_type.all ~f:(fun e -> (e, write ?dir t e))
+end
+
+(** Specification for a websocket channel. *)
+module type CHANNEL = sig
+  val name : string
+  (** The name of the channel *)
+
+  val version : string
+  (** The channel protocol version *)
+
+  val path : string list
+  (** The uri path for this channel *)
+
+  val authentication : [ `Private | `Public ]
+  (** Authentication syle for this channel. One of
+      [`Private] or [`Public]
+  *)
+
+  type uri_args [@@deriving sexp, enumerate]
+  (** Uri arguments which are appended to the end of
+      the path segment *)
+
+  val encode_uri_args : uri_args -> string
+  (** Encder from well typed uri arguments to a string
+      suitable for a uri.
+  *)
+
+  val default_uri_args : uri_args option
+  (** Defaut uri arguments. Optional for some channels. *)
+
+  type response [@@deriving sexp, of_yojson]
+  (** Respone type of the channel. Must have sexp converters
+      and a yojson parser *)
+
+  module Event_type : sig
+    include Json.S
+
+    val equal : t -> t -> bool
+  end
+
+  module Csv_of_event : CSV_OF_EVENTS with module Event_type = Event_type
+
+  val events_of_response : response -> Csv_of_event.t
+  (** Given a response value produce csvable events
+      modularized by event type. *)
+
+  type query [@@deriving sexp]
+  (** Query parameters for the channel *)
+
+  val encode_query : query -> string * string
+  (** Encodes queries as an http header key value pair *)
+end
+
+(** Creates a websocket implementation given a [Channel] *)
+module Impl (Channel : CHANNEL) = struct
+  (** Establishes a web socket client given configuration [Cfg]
+    and optional [query], [uri_args] and [nonce] parameters.
+
+    Produces a pipe of [Channel.response] instances.
+*)
+  let client (module Cfg : Cfg.S) ?query ?uri_args ?nonce () =
+    let query =
+      Option.map query ~f:(fun l ->
+          List.fold ~init:String.Map.empty l ~f:(fun map q ->
+              let key, data = Channel.encode_query (Channel.query_of_sexp q) in
+              Map.add_multi map ~key ~data)
+          |> fun map ->
+          let keys = Map.keys map in
+          List.map keys ~f:(fun k -> (k, Map.find_multi map k)))
+    in
+    let uri =
+      Uri.make ~host:Cfg.api_host ~scheme:"https" ?query
+        ~path:
+          (String.concat ~sep:"/"
+             (Channel.path
+             @ Option.(map ~f:Channel.encode_uri_args uri_args |> to_list)))
+        ()
+    in
+    Log.Global.info "Ws.client: uri=%s" (Uri.to_string uri);
+    let host = Option.value_exn ~message:"no host in uri" Uri.(host uri) in
+    let port = Option.value ~default:443 Uri_services.(tcp_port_of_uri uri) in
+    let scheme = Option.value ~default:"wss" Uri.(scheme uri) in
+    let tcp_fun s r w =
+      Socket.(setopt s Opt.nodelay true);
+      (if String.(equal scheme "https" || equal scheme "wss") then
+         Unix.Inet_addr.of_string_or_getbyname host >>| Ipaddr_unix.of_inet_addr
+         >>= fun addr ->
+         Conduit_async.(
+           connect
+             (`OpenSSL_with_config
+               ("wss", addr, port, Ssl.configure ~version:Tlsv1_2 ())))
+       else return (r, w))
+      >>= fun (r, w) ->
+      let payload = `Null in
+      let path = Path.to_string Channel.path in
+      let%bind payload =
+        match nonce with
+        | None -> return None
+        | Some nonce ->
+            Nonce.Request.(make ~nonce ~request:path ~payload () >>| to_yojson)
+            >>| fun s -> Yojson.Safe.to_string s |> Option.some
+      in
+      let extra_headers =
+        (match Channel.authentication with
+        | `Private ->
+            Option.map
+              ~f:(fun p -> Auth.(to_headers (module Cfg) (of_payload p)))
+              payload
+        | `Public -> None)
+        |> Option.value ~default:(Cohttp.Header.init ())
+      in
+      let r, _w =
+        Websocket_async.client_ez ~extra_headers
+          ~heartbeat:Time_ns.Span.(of_int_sec 5)
+          uri r w
+      in
+      Log.Global.info "input pipe established for channel %s" Channel.name;
+      Log.Global.flushed () >>| fun () ->
+      Pipe.map r ~f:(fun s ->
+          Yojson.Safe.from_string s |> Channel.response_of_yojson
+          |> Result.ok_or_failwith)
+    in
+    let hostport = Host_and_port.create ~host ~port in
+    Tcp.(with_connection Where_to_connect.(of_host_and_port hostport) tcp_fun)
+
+  let handle_client addr reader writer =
+    let addr_str = Socket.Address.(to_string addr) in
+    Log.Global.info "Client connection from %s" addr_str;
+    let app_to_ws, sender_write = Pipe.create () in
+    let receiver_read, ws_to_app = Pipe.create () in
+    let check_request req =
+      let req_str = Format.asprintf "%a" Cohttp.Request.pp_hum req in
+      Log.Global.info "Incoming connnection request: %s" req_str;
+      let path = Cohttp.Request.uri req |> Uri.path in
+      Deferred.return (String.equal path "/ws")
+    in
+    let rec loop () =
+      Pipe.read receiver_read >>= function
+      | `Eof ->
+          Log.Global.info "Client %s disconnected" addr_str;
+          Deferred.unit
+      | `Ok
+          ({ Websocket_async.Frame.opcode; extension = _; final = _; content }
+          as frame) ->
+          let open Websocket_async.Frame in
+          Log.Global.debug "<- %s" (show frame);
+          let frame', closed =
+            match opcode with
+            | Opcode.Ping ->
+                (Some (create ~opcode:Opcode.Pong ~content ()), false)
+            | Opcode.Close ->
+                (* Immediately echo and pass this last message to the user *)
+                if String.length content >= 2 then
+                  ( Some
+                      (create ~opcode:Opcode.Close
+                         ~content:(String.sub content ~pos:0 ~len:2)
+                         ()),
+                    true )
+                else (Some (close 100), true)
+            | Opcode.Pong -> (None, false)
+            | Opcode.Text | Opcode.Binary -> (Some frame, false)
+            | _ -> (Some (close 1002), false)
+          in
+          (match frame' with
+          | None -> Deferred.unit
+          | Some frame' ->
+              Log.Global.debug "-> %s" (show frame');
+              Pipe.write sender_write frame')
+          >>= fun () -> if closed then Deferred.unit else loop ()
+    in
+    Deferred.any
+      [
+        (Websocket_async.server ~check_request ~app_to_ws ~ws_to_app ~reader
+           ~writer ()
+         >>= function
+         | Error err -> (
+             match Error.to_exn err with
+             | Exit -> Deferred.unit
+             | (_ : Exn.t) -> Error.raise err)
+         | Ok () -> Deferred.unit);
+        loop ();
+      ]
+
+  let command =
+    let spec : (_, _) Command.Spec.t =
+      let open Command.Spec in
+      empty +> Cfg.param
+      +> flag "-loglevel" (optional int) ~doc:"1-3 loglevel"
+      +> flag "-query" (listed sexp) ~doc:"QUERY query parameters"
+      +> flag "-csv-dir" (optional string)
+           ~doc:
+             "PATH output each event type to a separate csv file at PATH. \
+              Defaults to current directory."
+      +> anon (maybe ("uri_args" %: sexp))
+    in
+    let set_loglevel = function
+      | 2 -> Log.Global.set_level `Info
+      | 3 -> Log.Global.set_level `Debug
+      | _ -> ()
+    in
+    let run cfg loglevel query (csv_dir : string option) uri_args () =
+      let cfg = Cfg.or_default cfg in
+      let module Cfg = (val cfg : Cfg.S) in
+      Option.iter loglevel ~f:set_loglevel;
+      let uri_args =
+        Option.first_some
+          (Option.map ~f:Channel.uri_args_of_sexp uri_args)
+          Channel.default_uri_args
+      in
+      let query =
+        match List.is_empty query with true -> None | false -> Some query
+      in
+      let%bind nonce = Nonce.File.(pipe ~init:default_filename) () in
+      Log.Global.info "Initiating channel %s with path %s" Channel.name
+        (Path.to_string Channel.path);
+      let channel_to_sexp_str response =
+        Channel.sexp_of_response response
+        |> Sexp.to_string_hum |> sprintf "%s\n"
+      in
+      let append_to_csv response =
+        let events = Channel.events_of_response response in
+        let all = Channel.Csv_of_event.write_all ?dir:csv_dir events in
+        let tags =
+          List.map all ~f:(fun (k, v) ->
+              (Channel.Event_type.to_string k, Int.to_string v))
+        in
+        Log.Global.debug ~tags "wrote csv response events";
+        ()
+      in
+      let pipe_reader response =
+        append_to_csv response;
+        channel_to_sexp_str response
+      in
+      client (module Cfg) ?query ?uri_args ~nonce () >>= fun pipe ->
+      Log.Global.debug "Broadcasting channel %s to stderr..." Channel.name;
+      Pipe.transfer pipe Writer.(pipe (Lazy.force stderr)) ~f:pipe_reader
+    in
+    ( Channel.name,
+      Command.async_spec
+        ~summary:
+          (sprintf "Gemini %s %s Websocket Command" Channel.version Channel.name)
+        spec run )
+end
+
+(** Create a websocket interface that has no request parameters *)
+module Make_no_request (Channel : CHANNEL) = struct
+  include Impl (Channel)
+
+  let client = client ?nonce:None
+end
+
+(** Create a websocket interface with request parameters *)
+module Make (Channel : CHANNEL) = struct
+  include Impl (Channel)
+
+  let client ~nonce = client ~nonce
+end


### PR DESCRIPTION
 - Factor out `trade` type and reuse in both `Order.Satus.response` and `Mytrades.response`.
 - Add new optional `break` field to the trade type and corresponding `Break_type.t` module and type definition.
 - Run `ocamlformat`
