### PR TITLE
Minimal fixes to release 0.3.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,7 +8,7 @@
  - Switch from `websockets-async` to simpler, better supported `cohttp_async_websocket`.
  - Fix various parse errors due to new gemini fields.
  - Format the codebase with ocamlformat
-
+ - Added --no-csv option to disable csv generation from command line.
 ## 0.2.1 (2019-03-03)
 
 - Write csv headers if target file is empty or does not exist.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,14 +1,16 @@
 ## 0.3.0 (2031-2-30)
 
- - Update to OCaml 5
- - Add support for many more symbols and currencies
- - Gracefully handle unknown currencies using new `Enum_or_string` abtraction
+ - Update to OCaml 5.
+ - Add support for many more symbols and currencies.
+ - Gracefully handle unknown currencies using new `Enum_or_string` abstraction.
  - Websocket pipes now retain result types when processing json rather than raising
    exceptions inside the pipe (breaking change).
  - Switch from `websockets-async` to simpler, better supported `cohttp_async_websocket`.
  - Fix various parse errors due to new gemini fields.
- - Format the codebase with ocamlformat
+ - Format the codebase with ocamlformat.
  - Added --no-csv option to disable csv generation from command line.
+ - Introduced `Poly_ok` utility module for unwrapping polymorphic variant result types.
+
 ## 0.2.1 (2019-03-03)
 
 - Write csv headers if target file is empty or does not exist.

--- a/gemini.opam
+++ b/gemini.opam
@@ -31,5 +31,5 @@ depends: [
   "ppx_csv_conv"
   "csvfields"
   "cohttp_async_websocket"
-  "expect_test_helpers"
+  "expect_test_helpers_core" {>= "v0.16.0"}
 ]

--- a/lib/common.ml
+++ b/lib/common.ml
@@ -134,8 +134,7 @@ end
 (** Represents currencies supported by Gemini. *)
 module Currency = struct
   module T = struct
-    (** An enumerated set of all supported currencies supported currently by
-        Gemini. *)
+    (** An enumerated set of all currencies supported currently by Gemini. *)
     type t =
       [ `Eth
       | `Btc
@@ -225,48 +224,53 @@ module Symbol = struct
       | `Qntusd
       ]
     [@@deriving sexp, enumerate, equal, compare]
-
-    let to_currency_pair : [< t ] -> Currency.t * Currency.t = function
-      | `Btcusd -> (`Btc, `Usd)
-      | `Bchusd -> (`Bch, `Usd)
-      | `Bchbtc -> (`Bch, `Btc)
-      | `Bcheth -> (`Bch, `Eth)
-      | `Ethusd -> (`Eth, `Usd)
-      | `Ethbtc -> (`Eth, `Btc)
-      | `Zecusd -> (`Zec, `Usd)
-      | `Zecbtc -> (`Zec, `Btc)
-      | `Zeceth -> (`Zec, `Eth)
-      | `Zecbch -> (`Zec, `Bch)
-      | `Zecltc -> (`Zec, `Ltc)
-      | `Ltcusd -> (`Ltc, `Usd)
-      | `Ltcbtc -> (`Ltc, `Btc)
-      | `Ltceth -> (`Ltc, `Eth)
-      | `Ltcbch -> (`Ltc, `Bch)
-      | `Lunausd -> (`Luna, `Usd)
-      | `Linkusd -> (`Link, `Usd)
-      | `Xtzusd -> (`Xtz, `Usd)
-      | `Aaveusd -> (`Aave, `Usd)
-      | `Crvusd -> (`Crv, `Usd)
-      | `Injusd -> (`Inj, `Usd)
-      | `Maticusd -> (`Matic, `Usd)
-      | `Ftmusd -> (`Ftm, `Usd)
-      | `Cubeusd -> (`Cube, `Usd)
-      | `Chzusd -> (`Chz, `Usd)
-      | `Dotusd -> (`Dot, `Usd)
-      | `Rareusd -> (`Rare, `Usd)
-      | `Qntusd -> (`Qnt, `Usd)
-
-    let to_currency : [< t ] -> Side.t -> Currency.t =
-     fun t side ->
-      to_currency_pair t |> fun (buy, sell) ->
-      match side with
-      | `Buy -> buy
-      | `Sell -> sell
   end
 
   include T
   module Enum = Json.Enum (T)
   include Enum
+
+  let to_currency_pair : [< t ] -> Currency.t * Currency.t = function
+    | `Btcusd -> (`Btc, `Usd)
+    | `Bchusd -> (`Bch, `Usd)
+    | `Bchbtc -> (`Bch, `Btc)
+    | `Bcheth -> (`Bch, `Eth)
+    | `Ethusd -> (`Eth, `Usd)
+    | `Ethbtc -> (`Eth, `Btc)
+    | `Zecusd -> (`Zec, `Usd)
+    | `Zecbtc -> (`Zec, `Btc)
+    | `Zeceth -> (`Zec, `Eth)
+    | `Zecbch -> (`Zec, `Bch)
+    | `Zecltc -> (`Zec, `Ltc)
+    | `Ltcusd -> (`Ltc, `Usd)
+    | `Ltcbtc -> (`Ltc, `Btc)
+    | `Ltceth -> (`Ltc, `Eth)
+    | `Ltcbch -> (`Ltc, `Bch)
+    | `Lunausd -> (`Luna, `Usd)
+    | `Linkusd -> (`Link, `Usd)
+    | `Xtzusd -> (`Xtz, `Usd)
+    | `Aaveusd -> (`Aave, `Usd)
+    | `Crvusd -> (`Crv, `Usd)
+    | `Injusd -> (`Inj, `Usd)
+    | `Maticusd -> (`Matic, `Usd)
+    | `Ftmusd -> (`Ftm, `Usd)
+    | `Cubeusd -> (`Cube, `Usd)
+    | `Chzusd -> (`Chz, `Usd)
+    | `Dotusd -> (`Dot, `Usd)
+    | `Rareusd -> (`Rare, `Usd)
+    | `Qntusd -> (`Qnt, `Usd)
+    | #t as c ->
+      to_string c |> fun s ->
+      let buy = String.prefix s 3 |> Currency.of_string_opt in
+      let sell = String.suffix s 3 |> Currency.of_string_opt in
+      Option.both buy sell |> Option.value_exn
+
+  let to_currency : [< t ] -> Side.t -> Currency.t =
+   fun t side ->
+    to_currency_pair t |> fun (buy, sell) ->
+    match side with
+    | `Buy -> buy
+    | `Sell -> sell
 
   include (Json.Make (Enum) : Json.S with type t := t)
 end

--- a/lib/common.ml
+++ b/lib/common.ml
@@ -230,42 +230,15 @@ module Symbol = struct
   module Enum = Json.Enum (T)
   include Enum
 
-  let to_currency_pair : [< t ] -> Currency.t * Currency.t = function
-    | `Btcusd -> (`Btc, `Usd)
-    | `Bchusd -> (`Bch, `Usd)
-    | `Bchbtc -> (`Bch, `Btc)
-    | `Bcheth -> (`Bch, `Eth)
-    | `Ethusd -> (`Eth, `Usd)
-    | `Ethbtc -> (`Eth, `Btc)
-    | `Zecusd -> (`Zec, `Usd)
-    | `Zecbtc -> (`Zec, `Btc)
-    | `Zeceth -> (`Zec, `Eth)
-    | `Zecbch -> (`Zec, `Bch)
-    | `Zecltc -> (`Zec, `Ltc)
-    | `Ltcusd -> (`Ltc, `Usd)
-    | `Ltcbtc -> (`Ltc, `Btc)
-    | `Ltceth -> (`Ltc, `Eth)
-    | `Ltcbch -> (`Ltc, `Bch)
-    | `Lunausd -> (`Luna, `Usd)
-    | `Linkusd -> (`Link, `Usd)
-    | `Xtzusd -> (`Xtz, `Usd)
-    | `Aaveusd -> (`Aave, `Usd)
-    | `Crvusd -> (`Crv, `Usd)
-    | `Injusd -> (`Inj, `Usd)
-    | `Maticusd -> (`Matic, `Usd)
-    | `Ftmusd -> (`Ftm, `Usd)
-    | `Cubeusd -> (`Cube, `Usd)
-    | `Chzusd -> (`Chz, `Usd)
-    | `Dotusd -> (`Dot, `Usd)
-    | `Rareusd -> (`Rare, `Usd)
-    | `Qntusd -> (`Qnt, `Usd)
+  let to_currency_pair :
+      [< t ] -> Currency.Enum_or_string.t * Currency.Enum_or_string.t = function
     | #t as c ->
       to_string c |> fun s ->
-      let buy = String.prefix s 3 |> Currency.of_string_opt in
-      let sell = String.suffix s 3 |> Currency.of_string_opt in
-      Option.both buy sell |> Option.value_exn
+      let buy = String.prefix s 3 |> Currency.Enum_or_string.of_string in
+      let sell = String.suffix s 3 |> Currency.Enum_or_string.of_string in
+      (buy, sell)
 
-  let to_currency : [< t ] -> Side.t -> Currency.t =
+  let to_currency : [< t ] -> Side.t -> Currency.Enum_or_string.t =
    fun t side ->
     to_currency_pair t |> fun (buy, sell) ->
     match side with

--- a/lib/gemini.ml
+++ b/lib/gemini.ml
@@ -6,6 +6,8 @@ module Rest = Rest
 module Result = Json.Result
 module Inf_pipe = Inf_pipe
 
+module Poly_ok = Poly_ok
+
 module V1 = struct
   let path = [ "v1" ]
 

--- a/lib/gemini.mli
+++ b/lib/gemini.mli
@@ -17,6 +17,7 @@ module Nonce = Nonce
 module Rest = Rest
 module Result = Json.Result
 module Inf_pipe = Inf_pipe
+module Poly_ok = Poly_ok
 
 (** Version v1 of the Gemini REST and web socket apis. *)
 module V1 : sig

--- a/lib/market_data.mli
+++ b/lib/market_data.mli
@@ -226,17 +226,9 @@ type response =
 [@@deriving sexp]
 
 include
-  Ws.CHANNEL
+  Ws.CHANNEL_CLIENT_NO_REQUEST
     with module Event_type := Event_type
     with type uri_args = Symbol.t
-    with type query = unit
     with type response := response
-
-val client :
-  (module Cfg.S) ->
-  ?query:Sexp.t list ->
-  ?uri_args:uri_args ->
-  unit ->
-  (response, string) result Pipe.Reader.t Deferred.t
 
 val command : string * Command.t

--- a/lib/order_events.mli
+++ b/lib/order_events.mli
@@ -161,18 +161,10 @@ module Event_type : sig
 end
 
 include
-  Ws.CHANNEL
+  Ws.CHANNEL_CLIENT
     with module Event_type := Event_type
     with type uri_args := uri_args
     with type query := query
     with type response := response
 
 val command : string * Async.Command.t
-
-val client :
-  nonce:int Inf_pipe.Reader.t ->
-  (module Cfg.S) ->
-  ?query:Sexp.t list ->
-  ?uri_args:uri_args ->
-  unit ->
-  (response, string) result Pipe.Reader.t Deferred.t

--- a/lib/poly_ok.ml
+++ b/lib/poly_ok.ml
@@ -1,0 +1,27 @@
+type 'a ok = [ `Ok of 'a ]
+
+let ok_exn ?(message = "not_ok") ?here ?sexp_of_error (x : [> 'a ok ]) =
+  match x with
+  | `Ok x -> x
+  | error -> (
+    match sexp_of_error with
+    | Some f ->
+      failwiths message ~here:(Option.value here ~default:[%here]) error f
+    | None -> failwith message )
+
+let ok_or_none (x : [> 'a ok ]) =
+  match x with
+  | `Ok x -> Some x
+  | _ -> None
+
+let ok_or_error_s (x : [> 'a ok ]) sexp_of_error =
+  match x with
+  | `Ok x -> Or_error.return x
+  | e -> Or_error.error_s (sexp_of_error e)
+
+let ok_or_error (x : [> 'a ok ]) string_of_error =
+  match x with
+  | `Ok x -> Or_error.return x
+  | e -> Or_error.error_string @@ string_of_error e
+
+let ok (x : 'a) : 'a ok = `Ok x

--- a/lib/ws.ml
+++ b/lib/ws.ml
@@ -376,27 +376,24 @@ module Impl (Channel : CHANNEL) :
 end
 
 (** Create a websocket interface that has no request parameters *)
-module Make_no_request
-    (Channel : CHANNEL with type query = unit)
-(*:  CHANNEL_CLIENT_NO_REQUEST
+module Make_no_request (Channel : CHANNEL with type query = unit) :
+  CHANNEL_CLIENT_NO_REQUEST
     with type response = Channel.response
      and type uri_args = Channel.uri_args
-     and type query = unit *) =
-struct
+     and type query = unit = struct
+  include Channel
   include Impl (Channel)
 
   let client = client ?nonce:None
 end
 
 (** Create a websocket interface with request parameters *)
-module Make
-    (Channel : CHANNEL)
-(*:
+module Make (Channel : CHANNEL) :
   CHANNEL_CLIENT
     with type response = Channel.response
      and type uri_args = Channel.uri_args
-     and type query = Channel.query *) =
-struct
+     and type query = Channel.query = struct
+  include Channel
   include Impl (Channel)
 
   let client (module Cfg : Cfg.S) ~nonce = client (module Cfg) ~nonce

--- a/lib/ws.ml
+++ b/lib/ws.ml
@@ -378,9 +378,10 @@ end
 (** Create a websocket interface that has no request parameters *)
 module Make_no_request (Channel : CHANNEL with type query = unit) :
   CHANNEL_CLIENT_NO_REQUEST
-    with type response = Channel.response
-     and type uri_args = Channel.uri_args
-     and type query = unit = struct
+    with type response := Channel.response
+     and type uri_args := Channel.uri_args
+     and module Event_type := Channel.Event_type
+     and type query := unit = struct
   include Channel
   include Impl (Channel)
 
@@ -390,9 +391,10 @@ end
 (** Create a websocket interface with request parameters *)
 module Make (Channel : CHANNEL) :
   CHANNEL_CLIENT
-    with type response = Channel.response
-     and type uri_args = Channel.uri_args
-     and type query = Channel.query = struct
+    with type response := Channel.response
+     and type uri_args := Channel.uri_args
+     and module Event_type := Channel.Event_type
+     and type query := Channel.query = struct
   include Channel
   include Impl (Channel)
 

--- a/lib/ws.ml
+++ b/lib/ws.ml
@@ -8,12 +8,20 @@ module type EVENT_CSVABLE = sig
   val events : t list
 end
 
-module type CSV_OF_EVENTS = sig
-  module Event_type : sig
-    include Json.S
+module type EVENT_TYPE = sig
+  type t [@@deriving sexp]
 
-    val equal : t -> t -> bool
-  end
+  include Json.S with type t := t
+
+  include Comparable.S with type t := t
+
+  val equal : t -> t -> bool
+
+  val __t_of_sexp__ : Sexp.t -> t
+end
+
+module type CSV_OF_EVENTS = sig
+  module Event_type : EVENT_TYPE
 
   type t
 
@@ -35,11 +43,8 @@ module type CSV_OF_EVENTS = sig
   val write_all : ?dir:string -> t -> (Event_type.t * int) list
 end
 
-module Csv_of_event (Event_type : sig
-  include Json.S
-
-  include Comparable with type t := t
-end) : CSV_OF_EVENTS with module Event_type = Event_type = struct
+module Csv_of_event (Event_type : EVENT_TYPE) :
+  CSV_OF_EVENTS with module Event_type = Event_type = struct
   type t = (module EVENT_CSVABLE) list Event_type.Map.t
 
   let empty : t = Event_type.Map.empty
@@ -136,11 +141,7 @@ module type CHANNEL = sig
   (** Respone type of the channel. Must have sexp converters and a yojson parser *)
   type response [@@deriving sexp, of_yojson]
 
-  module Event_type : sig
-    include Json.S
-
-    val equal : t -> t -> bool
-  end
+  module Event_type : EVENT_TYPE
 
   module Csv_of_event : CSV_OF_EVENTS with module Event_type = Event_type
 
@@ -154,13 +155,91 @@ module type CHANNEL = sig
   val encode_query : query -> string * string
 end
 
+module Error = struct
+  type t =
+    [ `Json_parse_error of string
+    | `Channel_parse_error of string
+    ]
+  [@@deriving sexp, yojson]
+end
+
+module type RESULT = sig
+  type response [@@deriving sexp, of_yojson]
+
+  type ok = [ `Ok of response ] [@@deriving sexp, of_yojson]
+
+  type t =
+    [ ok
+    | Error.t
+    ]
+  [@@deriving sexp, of_yojson]
+end
+
+module type CHANNEL_CLIENT_BASE = sig
+  include CHANNEL
+
+  module Error : module type of Error
+
+  val command : string * Command.t
+end
+
+module type CHANNEL_CLIENT_INTERNAL = sig
+  include CHANNEL_CLIENT_BASE
+
+  val client :
+    (module Cfg.S) ->
+    ?query:Sexp.t list ->
+    ?uri_args:uri_args ->
+    ?nonce:int Inf_pipe.Reader.t ->
+    unit ->
+    [ `Ok of response | Error.t ] Pipe.Reader.t Deferred.t
+end
+
+module type CHANNEL_CLIENT_NO_REQUEST = sig
+  include CHANNEL_CLIENT_BASE
+
+  val client :
+    (module Cfg.S) ->
+    ?query:Sexp.t list ->
+    ?uri_args:uri_args ->
+    unit ->
+    [ `Ok of response | Error.t ] Pipe.Reader.t Deferred.t
+end
+
+module type CHANNEL_CLIENT = sig
+  include CHANNEL_CLIENT_BASE
+
+  module Error : module type of Error
+
+  val command : string * Command.t
+
+  val client :
+    (module Cfg.S) ->
+    nonce:Nonce.reader ->
+    ?query:Sexp.t list ->
+    ?uri_args:uri_args ->
+    unit ->
+    [ `Ok of response | Error.t ] Pipe.Reader.t Deferred.t
+end
+
 (** Creates a websocket implementation given a [Channel] *)
-module Impl (Channel : CHANNEL) = struct
+module Impl (Channel : CHANNEL) :
+  CHANNEL_CLIENT_INTERNAL
+    with type response := Channel.response
+     and type uri_args = Channel.uri_args
+     and module Event_type = Channel.Event_type
+     and type query = Channel.query
+     and module Error = Error = struct
   (** Establishes a web socket client given configuration [Cfg] and optional
       [query], [uri_args] and [nonce] parameters.
 
       Produces a pipe of [(Channel.response, string) result] instances. *)
-  let client (module Cfg : Cfg.S) ?query ?uri_args ?nonce () =
+
+  include Channel
+  module Error = Error
+
+  let client (module Cfg : Cfg.S) ?query ?uri_args ?nonce () :
+      [ `Ok of response | Error.t ] Pipe.Reader.t Deferred.t =
     let query =
       Option.map query ~f:(fun l ->
           List.fold ~init:String.Map.empty l ~f:(fun map q ->
@@ -200,18 +279,18 @@ module Impl (Channel : CHANNEL) = struct
     Cohttp_async_websocket.Client.create ~headers uri >>= fun x ->
     Or_error.ok_exn x |> return >>= fun (_response, ws) ->
     let r, _w = Websocket.pipes ws in
-    Log.Global.info "input pipe established for channel %s" Channel.name;
     Log.Global.flushed () >>| fun () ->
-    (* TODO Use polymorphic variants for the error conditions in the pipe *)
     let pipe =
       Pipe.map r ~f:(fun s ->
           Log.Global.debug "json of event: %s" s;
-          ( try Yojson.Safe.from_string s |> Result.return with
-          | Yojson.Json_error _ as e -> begin
-            Log.Global.info_s (Exn.sexp_of_t e);
-            Result.Error (Exn.to_string e)
-          end )
-          |> Result.bind ~f:Channel.response_of_yojson )
+          ( try `Ok (Yojson.Safe.from_string s) with
+          | Yojson.Json_error e -> `Json_parse_error e )
+          |> function
+          | #Error.t as e -> e
+          | `Ok json -> (
+            match Channel.response_of_yojson json with
+            | Ok response -> `Ok response
+            | Error e -> `Channel_parse_error e ) )
     in
     pipe
 
@@ -281,9 +360,10 @@ module Impl (Channel : CHANNEL) = struct
       Log.Global.debug "Broadcasting channel %s to stderr..." Channel.name;
       let pipe =
         Pipe.filter_map pipe ~f:(function
-          | Result.Ok ok -> Some ok
-          | Result.Error e ->
-            Log.Global.error "Failed to parse last event: %s" e;
+          | `Ok ok -> Some ok
+          | #Error.t as e ->
+            Log.Global.error "Failed to parse last event: %s"
+              (Error.sexp_of_t e |> Sexp.to_string);
             None )
       in
       Pipe.transfer pipe Writer.(pipe (Lazy.force stderr)) ~f:ok_pipe_reader
@@ -296,15 +376,28 @@ module Impl (Channel : CHANNEL) = struct
 end
 
 (** Create a websocket interface that has no request parameters *)
-module Make_no_request (Channel : CHANNEL) = struct
+module Make_no_request
+    (Channel : CHANNEL with type query = unit)
+(*:  CHANNEL_CLIENT_NO_REQUEST
+    with type response = Channel.response
+     and type uri_args = Channel.uri_args
+     and type query = unit *) =
+struct
   include Impl (Channel)
 
   let client = client ?nonce:None
 end
 
 (** Create a websocket interface with request parameters *)
-module Make (Channel : CHANNEL) = struct
+module Make
+    (Channel : CHANNEL)
+(*:
+  CHANNEL_CLIENT
+    with type response = Channel.response
+     and type uri_args = Channel.uri_args
+     and type query = Channel.query *) =
+struct
   include Impl (Channel)
 
-  let client ~nonce = client ~nonce
+  let client (module Cfg : Cfg.S) ~nonce = client (module Cfg) ~nonce
 end

--- a/test/auth.ml
+++ b/test/auth.ml
@@ -1,11 +1,10 @@
-
 open Gemini
 open! Gemini.V1
 
 let api_secret = "1234abcd"
 
 let request_str =
-{|{
+  {|{
      "request": "/v1/order/status",
      "nonce": 123456,
 
@@ -18,7 +17,6 @@ let hex_encoding_test () =
   printf "%s" (Auth.to_string hex);
   ()
 
-
 let hmac384_encrypting_test () =
   let hex = Auth.of_payload request_str in
   let hmac = Auth.hmac_sha384 ~api_secret hex in
@@ -27,9 +25,11 @@ let hmac384_encrypting_test () =
   ()
 
 let%expect_test "hex encoding" =
-  hex_encoding_test () |> fun () ->
-  [%expect "ewogICAgICJyZXF1ZXN0IjogIi92MS9vcmRlci9zdGF0dXMiLAogICAgICJub25jZSI6IDEyMzQ1NiwKCiAgICAgIm9yZGVyX2lkIjogMTg4MzQKfQo="]
+  hex_encoding_test () |> return >>| fun () ->
+  [%expect
+    "ewogICAgICJyZXF1ZXN0IjogIi92MS9vcmRlci9zdGF0dXMiLAogICAgICJub25jZSI6IDEyMzQ1NiwKCiAgICAgIm9yZGVyX2lkIjogMTg4MzQKfQo="]
 
 let%expect_test "hmac384 encrypting" =
-  hmac384_encrypting_test () |> fun () ->
-  [%expect "aceaacbe56beb3b08c9f1b4bfd099cc523f8c15b36ccd0fdcf823e71ea6ff413b5a1de251cfab9c3c0e863739d76368f"]
+  hmac384_encrypting_test () |> return >>| fun () ->
+  [%expect
+    "aceaacbe56beb3b08c9f1b4bfd099cc523f8c15b36ccd0fdcf823e71ea6ff413b5a1de251cfab9c3c0e863739d76368f"]

--- a/test/dune
+++ b/test/dune
@@ -1,11 +1,11 @@
 (library
   (name gemini_test)
   (library_flags -linkall)
-  (libraries gemini expect_test_helpers)
+  (libraries gemini expect_test_helpers_core)
   (synopsis "Gemini Client unit tester")
 
   (flags :standard -open Core -open Async
-   -open Expect_test_helpers_kernel)
+   -open Expect_test_helpers_core)
   (inline_tests (flags :standard) (deps (universe)))
   (preprocess (pps ppx_jane))
 


### PR DESCRIPTION
- Change `to_currency_pair` to use enum or string api.
- Update ` gemini.opam` lower bounds
- Change `expect_test_helper` dependency to `expect_test_helpers_core`
- Update some documentation and changelog
- Introduce `Poly_ok` convenience module for unwrapping polymorphic variant types.